### PR TITLE
Create new array shuffled flow based on the Refinery

### DIFF
--- a/Modules/Test/classes/class.ilObjTestGUI.php
+++ b/Modules/Test/classes/class.ilObjTestGUI.php
@@ -156,6 +156,7 @@ class ilObjTestGUI extends ilObjectGUI
         $tree = $DIC['tree'];
         $ilias = $DIC['ilias'];
         $ilUser = $DIC['ilUser'];
+        $randomGroup = $DIC->refinery()->random();
 
         $cmd = $this->ctrl->getCmd("infoScreen");
 
@@ -659,7 +660,7 @@ class ilObjTestGUI extends ilObjectGUI
                 $this->ctrl->saveParameter($this, "q_id");
 
                 require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php';
-                $gui = new ilAssQuestionPreviewGUI($this->ctrl, $this->tabs_gui, $this->tpl, $this->lng, $ilDB, $ilUser);
+                $gui = new ilAssQuestionPreviewGUI($this->ctrl, $this->tabs_gui, $this->tpl, $this->lng, $ilDB, $ilUser, $randomGroup);
 
                 $gui->initQuestion($this->fetchAuthoringQuestionIdParameter(), $this->object->getId());
                 $gui->initPreviewSettings($this->object->getRefId());

--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -1,6 +1,11 @@
 <?php
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\Random\Seed\RandomSeed;
+use ILIAS\Refinery\Random\Seed\GivenSeed;
+use ILIAS\Refinery\Random\Group as RandomGroup;
+
 require_once './Modules/Test/classes/inc.AssessmentConstants.php';
 require_once './Modules/Test/classes/class.ilTestPlayerCommands.php';
 require_once './Modules/Test/classes/class.ilTestServiceGUI.php';
@@ -61,6 +66,8 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
      */
     protected $testSequence = null;
 
+    private RandomGroup $randomGroup;
+
     /**
     * ilTestOutputGUI constructor
     *
@@ -81,6 +88,7 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
         $this->processLocker = null;
         $this->testSession = null;
         $this->assSettings = null;
+        $this->randomGroup = $DIC->refinery()->random();
     }
 
     protected function checkReadAccess()
@@ -2534,17 +2542,13 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
     
     /**
      * @param $questionId
-     * @return ilArrayElementShuffler
+     * @return Transformation
      */
     protected function buildQuestionAnswerShuffler($questionId)
     {
-        require_once 'Services/Randomization/classes/class.ilArrayElementShuffler.php';
-        $shuffler = new ilArrayElementShuffler();
-        
         $fixedSeed = $this->buildFixedShufflerSeed($questionId);
-        $shuffler->setSeed($fixedSeed);
-        
-        return $shuffler;
+
+        return $this->randomGroup->shuffleArray(new GivenSeed($fixedSeed));
     }
 
     /**

--- a/Modules/Test/test/ilTestBaseTestCase.php
+++ b/Modules/Test/test/ilTestBaseTestCase.php
@@ -9,6 +9,8 @@ use ILIAS\FileUpload\FileUpload;
 use ILIAS\Filesystem\Filesystems;
 use ILIAS\HTTP\Services;
 use ILIAS\UI\Implementation\Factory;
+use ILIAS\Refinery\Factory as RefineryFactory;
+use ILIAS\Refinery\Random\Group as RandomGroup;
 
 /**
  * Class ilTestBaseClass
@@ -215,5 +217,12 @@ class ilTestBaseTestCase extends TestCase
     protected function addGlobal_uiRenderer() : void
     {
         $this->setGlobalVariable("ui.renderer", $this->createMock(ILIAS\UI\Implementation\DefaultRenderer::class));
+    }
+
+    protected function addGlobal_refinery() : void
+    {
+        $refineryMock = $this->getMockBuilder(RefineryFactory::class)->disableOriginalConstructor()->getMock();
+        $refineryMock->expects(self::any())->method('random')->willReturn($this->getMockBuilder(RandomGroup::class)->getMock());
+        $this->setGlobalVariable("refinery", $refineryMock);
     }
 }

--- a/Modules/Test/test/ilTestPlayerDynamicQuestionSetGUITest.php
+++ b/Modules/Test/test/ilTestPlayerDynamicQuestionSetGUITest.php
@@ -25,6 +25,7 @@ class ilTestPlayerDynamicQuestionSetGUITest extends ilTestBaseTestCase
         $this->addGlobal_ilObjDataCache();
         $this->addGlobal_rbacsystem();
         $this->addGlobal_ilUser();
+        $this->addGlobal_refinery();
 
         $_GET["ref_id"] = 2;
 

--- a/Modules/Test/test/ilTestPlayerFactoryTest.php
+++ b/Modules/Test/test/ilTestPlayerFactoryTest.php
@@ -40,6 +40,7 @@ class ilTestPlayerFactoryTest extends ilTestBaseTestCase
         $this->addGlobal_ilObjDataCache();
         $_GET["ref_id"] = 2;
         $this->addGlobal_rbacsystem();
+        $this->addGlobal_refinery();
 
         $objTest = new ilObjTest();
 

--- a/Modules/Test/test/ilTestPlayerFixedQuestionSetGUITest.php
+++ b/Modules/Test/test/ilTestPlayerFixedQuestionSetGUITest.php
@@ -27,6 +27,7 @@ class ilTestPlayerFixedQuestionSetGUITest extends ilTestBaseTestCase
         $this->addGlobal_ilObjDataCache();
         $this->addGlobal_rbacsystem();
         $this->addGlobal_ilUser();
+        $this->addGlobal_refinery();
 
         $this->testObj = new ilTestPlayerFixedQuestionSetGUI(
             $this->createMock(ilObjTest::class)

--- a/Modules/Test/test/ilTestPlayerRandomQuestionSetGUITest.php
+++ b/Modules/Test/test/ilTestPlayerRandomQuestionSetGUITest.php
@@ -25,6 +25,7 @@ class ilTestPlayerRandomQuestionSetGUITest extends ilTestBaseTestCase
         $this->addGlobal_ilObjDataCache();
         $this->addGlobal_rbacsystem();
         $this->addGlobal_ilUser();
+        $this->addGlobal_refinery();
 
         $_GET["ref_id"] = "0";
 

--- a/Modules/TestQuestionPool/classes/class.assClozeGap.php
+++ b/Modules/TestQuestionPool/classes/class.assClozeGap.php
@@ -1,6 +1,8 @@
 <?php
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Refinery\Transformation;
+
 include_once "./Modules/Test/classes/inc.AssessmentConstants.php";
 
 /**
@@ -85,13 +87,13 @@ class assClozeGap
     /**
      * Gets the items of a cloze gap
      *
-     * @param ilRandomArrayElementProvider $shuffler
+     * @param Transformation $shuffler
      * @return assAnswerCloze[] The list of items
      */
-    public function getItems(ilRandomArrayElementProvider $shuffler)
+    public function getItems(Transformation $shuffler) : array
     {
         if ($this->getShuffle()) {
-            return $shuffler->shuffle($this->items);
+            return $shuffler->transform($this->items);
         }
         
         return $this->items;
@@ -334,11 +336,11 @@ class assClozeGap
     }
 
     /**
-     * @param ilRandomArrayElementProvider $shuffler
+     * @param Transformation $shuffler
      * @param null | array $combinations
      * @return string
      */
-    public function getBestSolutionOutput(ilRandomArrayElementProvider $shuffler, $combinations = null)
+    public function getBestSolutionOutput(Transformation $shuffler, $combinations = null)
     {
         global $DIC;
         $lng = $DIC['lng'];

--- a/Modules/TestQuestionPool/classes/class.assClozeTest.php
+++ b/Modules/TestQuestionPool/classes/class.assClozeTest.php
@@ -1,6 +1,8 @@
 <?php
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Refinery\Random\Group as RandomGroup;
+
 require_once './Modules/TestQuestionPool/classes/class.assQuestion.php';
 require_once './Modules/Test/classes/inc.AssessmentConstants.php';
 require_once './Modules/TestQuestionPool/classes/class.assClozeGapCombination.php';
@@ -101,6 +103,8 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
 
     protected $feedbackMode = ilAssClozeTestFeedback::FB_MODE_GAP_QUESTION;
 
+    private RandomGroup $randomGroup;
+
     /**
      * assClozeTest constructor
      *
@@ -121,6 +125,8 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
         $owner = -1,
         $question = ""
     ) {
+        global $DIC;
+
         parent::__construct($title, $comment, $author, $owner, $question);
         $this->start_tag = "[gap]";
         $this->end_tag = "[/gap]";
@@ -130,6 +136,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
         $this->identical_scoring = 1;
         $this->gap_combinations_exists = false;
         $this->gap_combinations = array();
+        $this->randomGroup = $DIC->refinery()->random();
     }
 
     /**
@@ -2010,7 +2017,7 @@ class assClozeTest extends assQuestion implements ilObjQuestionScoringAdjustable
             return false;
         }
 
-        foreach ($gap->getItems(new ilDeterministicArrayElementProvider()) as $item) {
+        foreach ($gap->getItems($this->randomGroup->dontShuffle()) as $item) {
             if ($item->getAnswertext() == $answerOptionValue) {
                 return false;
             }

--- a/Modules/TestQuestionPool/classes/class.assKprimChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assKprimChoiceGUI.php
@@ -707,7 +707,7 @@ class assKprimChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringAd
         $choiceKeys = array_keys($this->object->getAnswers());
 
         if ($this->object->isShuffleAnswersEnabled()) {
-            $choiceKeys = $this->object->getShuffler()->shuffle($choiceKeys);
+            $choiceKeys = $this->object->getShuffler()->transform($choiceKeys);
         }
 
         return $choiceKeys;

--- a/Modules/TestQuestionPool/classes/class.assMatchingQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assMatchingQuestion.php
@@ -1,6 +1,9 @@
 <?php
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Refinery\Random\Group as RandomGroup;
+use ILIAS\Refinery\Random\Seed\RandomSeed;
+
 require_once './Modules/TestQuestionPool/classes/class.assQuestion.php';
 require_once './Modules/Test/classes/inc.AssessmentConstants.php';
 require_once './Modules/TestQuestionPool/interfaces/interface.ilObjQuestionScoringAdjustable.php';
@@ -68,6 +71,8 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
 
     protected $matchingMode = self::MATCHING_MODE_1_ON_1;
 
+    private RandomGroup $randomGroup;
+
     /**
      * assMatchingQuestion constructor
      *
@@ -90,11 +95,14 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
         $question = "",
         $matching_type = MT_TERMS_DEFINITIONS
     ) {
+        global $DIC;
+
         parent::__construct($title, $comment, $author, $owner, $question);
         $this->matchingpairs = array();
         $this->matching_type = $matching_type;
         $this->terms = array();
         $this->definitions = array();
+        $this->randomGroup = $DIC->refinery()->random();
     }
 
     /**
@@ -1380,14 +1388,11 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
             'onenotcorrect' => $this->formatSAQuestion($this->feedbackOBJ->getGenericFeedbackTestPresentation($this->getId(), false)),
             'allcorrect' => $this->formatSAQuestion($this->feedbackOBJ->getGenericFeedbackTestPresentation($this->getId(), true))
         );
-        
-        require_once 'Services/Randomization/classes/class.ilArrayElementShuffler.php';
-        $this->setShuffler(new ilArrayElementShuffler());
-        $seed = $this->getShuffler()->getSeed();
+
+        $this->setShuffler($this->randomGroup->shuffleArray(new RandomSeed()));
         
         $terms = array();
-        $this->getShuffler()->setSeed($this->getShuffler()->buildSeedFromString($seed . 'terms'));
-        foreach ($this->getShuffler()->shuffle($this->getTerms()) as $term) {
+        foreach ($this->getShuffler()->transform($this->getTerms()) as $term) {
             $terms[] = array(
                 "text" => $this->formatSAQuestion($term->text),
                 "id" => (int) $this->getId() . $term->identifier
@@ -1403,8 +1408,7 @@ class assMatchingQuestion extends assQuestion implements ilObjQuestionScoringAdj
         // when the second one (the copy) is answered.
 
         $definitions = array();
-        $this->getShuffler()->setSeed($this->getShuffler()->buildSeedFromString($seed . 'definitions'));
-        foreach ($this->getShuffler()->shuffle($this->getDefinitions()) as $def) {
+        foreach ($this->getShuffler()->transform($this->getDefinitions()) as $def) {
             $definitions[] = array(
                 "text" => $this->formatSAQuestion((string) $def->text),
                 "id" => (int) $this->getId() . $def->identifier

--- a/Modules/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assMatchingQuestionGUI.php
@@ -632,18 +632,14 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $definitions = $this->object->getDefinitions();
         switch ($this->object->getShuffle()) {
             case 1:
-                $seed = $this->object->getShuffler()->getSeed();
-                $this->object->getShuffler()->setSeed($seed . '1');
-                $terms = $this->object->getShuffler()->shuffle($terms);
-                $this->object->getShuffler()->setSeed($seed . '2');
-                $definitions = $this->object->getShuffler()->shuffle($definitions);
-                $this->object->getShuffler()->setSeed($seed);
+                $terms = $this->object->getShuffler()->transform($terms);
+                $definitions = $this->object->getShuffler()->transform($definitions);
                 break;
             case 2:
-                $terms = $this->object->getShuffler()->shuffle($terms);
+                $terms = $this->object->getShuffler()->transform($terms);
                 break;
             case 3:
-                $definitions = $this->object->getShuffler()->shuffle($definitions);
+                $definitions = $this->object->getShuffler()->transform($definitions);
                 break;
         }
 
@@ -828,25 +824,21 @@ class assMatchingQuestionGUI extends assQuestionGUI implements ilGuiQuestionScor
         $definitions = $this->object->getDefinitions();
         switch ($this->object->getShuffle()) {
             case 1:
-                $seed = $this->object->getShuffler()->getSeed();
-                $this->object->getShuffler()->setSeed($seed . '1');
-                $terms = $this->object->getShuffler()->shuffle($terms);
+                $terms = $this->object->getShuffler()->transform($terms);
                 if (count($solutions)) {
                     $definitions = $this->sortDefinitionsBySolution($solutions, $definitions);
                 } else {
-                    $this->object->getShuffler()->setSeed($seed . '2');
-                    $definitions = $this->object->getShuffler()->shuffle($definitions);
+                    $definitions = $this->object->getShuffler()->transform($definitions);
                 }
-                $this->object->getShuffler()->setSeed($seed);
                 break;
             case 2:
-                $terms = $this->object->getShuffler()->shuffle($terms);
+                $terms = $this->object->getShuffler()->transform($terms);
                 break;
             case 3:
                 if (count($solutions)) {
                     $definitions = $this->sortDefinitionsBySolution($solutions, $definitions);
                 } else {
-                    $definitions = $this->object->getShuffler()->shuffle($definitions);
+                    $definitions = $this->object->getShuffler()->transform($definitions);
                 }
                 break;
         }

--- a/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assMultipleChoiceGUI.php
@@ -737,7 +737,7 @@ class assMultipleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScorin
         $choiceKeys = array_keys($this->object->answers);
 
         if ($this->object->getShuffle()) {
-            $choiceKeys = $this->object->getShuffler()->shuffle($choiceKeys);
+            $choiceKeys = $this->object->getShuffler()->transform($choiceKeys);
         }
 
         return $choiceKeys;

--- a/Modules/TestQuestionPool/classes/class.assOrderingHorizontal.php
+++ b/Modules/TestQuestionPool/classes/class.assOrderingHorizontal.php
@@ -524,7 +524,7 @@ class assOrderingHorizontal extends assQuestion implements ilObjQuestionScoringA
     public function getRandomOrderingElements()
     {
         $elements = $this->getOrderingElements();
-        $elements = $this->getShuffler()->shuffle($elements);
+        $elements = $this->getShuffler()->transform($elements);
         return $elements;
     }
     

--- a/Modules/TestQuestionPool/classes/class.assOrderingQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assOrderingQuestion.php
@@ -544,7 +544,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
      */
     public function getShuffledOrderingElementList()
     {
-        $shuffledRandomIdentifierIndex = $this->getShuffler()->shuffle(
+        $shuffledRandomIdentifierIndex = $this->getShuffler()->transform(
             $this->getOrderingElementList()->getRandomIdentifierIndex()
         );
         
@@ -1163,7 +1163,7 @@ class assOrderingQuestion extends assQuestion implements ilObjQuestionScoringAdj
             $answers[$counter] = $orderingElement->getContent();
             $counter++;
         }
-        $answers = $this->getShuffler()->shuffle($answers);
+        $answers = $this->getShuffler()->transform($answers);
         $arr = array();
         foreach ($answers as $order => $answer) {
             array_push($arr, array(

--- a/Modules/TestQuestionPool/classes/class.assQuestion.php
+++ b/Modules/TestQuestionPool/classes/class.assQuestion.php
@@ -1,6 +1,8 @@
 <?php
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Refinery\Transformation;
+
 require_once './Modules/Test/classes/inc.AssessmentConstants.php';
 require_once dirname(__DIR__) . '../../../libs/composer/vendor/autoload.php';
 
@@ -153,7 +155,7 @@ abstract class assQuestion
     
     protected $lastChange;
 
-    protected \ilRandomArrayElementProvider $shuffler;
+    protected Transformation $shuffler;
 
     private bool $obligationsToBeConsidered = false;
 
@@ -166,7 +168,7 @@ abstract class assQuestion
         'image/png' => array('png'),
         'image/gif' => array('gif')
     );
-    
+
     /**
      * assQuestion constructor
      */
@@ -212,7 +214,7 @@ abstract class assQuestion
 
         $this->questionActionCmd = 'handleQuestionAction';
 
-        $this->shuffler = new ilDeterministicArrayElementProvider();
+        $this->shuffler = $DIC->refinery()->random()->dontShuffle();
         $this->lifecycle = ilAssQuestionLifecycle::getDraftInstance();
     }
     
@@ -360,12 +362,12 @@ abstract class assQuestion
         return array_unique($extensions);
     }
 
-    public function getShuffler() : ilRandomArrayElementProvider
+    public function getShuffler() : Transformation
     {
         return $this->shuffler;
     }
 
-    public function setShuffler(ilRandomArrayElementProvider $shuffler) : void
+    public function setShuffler(Transformation $shuffler) : void
     {
         $this->shuffler = $shuffler;
     }

--- a/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
+++ b/Modules/TestQuestionPool/classes/class.assSingleChoiceGUI.php
@@ -610,7 +610,7 @@ class assSingleChoiceGUI extends assQuestionGUI implements ilGuiQuestionScoringA
         $choiceKeys = array_keys($this->object->answers);
         
         if ($this->object->getShuffle()) {
-            $choiceKeys = $this->object->getShuffler()->shuffle($choiceKeys);
+            $choiceKeys = $this->object->getShuffler()->transform($choiceKeys);
         }
         
         return $choiceKeys;

--- a/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php
@@ -1,6 +1,10 @@
 <?php
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Refinery\Random\Group as RandomGroup;
+use ILIAS\Refinery\Random\Seed\RandomSeed;
+use ILIAS\Refinery\Random\Seed\GivenSeed;
+use ILIAS\Refinery\Transformation;
 
 /**
  * @author		Björn Heyser <bheyser@databay.de>
@@ -82,8 +86,10 @@ class ilAssQuestionPreviewGUI
      * @var ilAssQuestionPreviewHintTracking
      */
     protected $hintTracking;
+
+    private RandomGroup $randomGroup;
     
-    public function __construct(ilCtrl $ctrl, ilTabsGUI $tabs, ilGlobalTemplateInterface $tpl, ilLanguage $lng, ilDBInterface $db, ilObjUser $user)
+    public function __construct(ilCtrl $ctrl, ilTabsGUI $tabs, ilGlobalTemplateInterface $tpl, ilLanguage $lng, ilDBInterface $db, ilObjUser $user, RandomGroup $randomGroup)
     {
         $this->ctrl = $ctrl;
         $this->tabs = $tabs;
@@ -91,6 +97,7 @@ class ilAssQuestionPreviewGUI
         $this->lng = $lng;
         $this->db = $db;
         $this->user = $user;
+        $this->randomGroup = $randomGroup;
     }
 
     public function initQuestion($questionId, $parentObjId)
@@ -543,20 +550,15 @@ class ilAssQuestionPreviewGUI
     }
 
     /**
-     * @return ilArrayElementShuffler
+     * @return Transformation
      */
     private function getQuestionAnswerShuffler()
     {
-        require_once 'Services/Randomization/classes/class.ilArrayElementShuffler.php';
-        $shuffler = new ilArrayElementShuffler();
-        
         if (!$this->previewSession->randomizerSeedExists()) {
-            $this->previewSession->setRandomizerSeed($shuffler->buildRandomSeed());
+            $this->previewSession->setRandomizerSeed((new RandomSeed())->createSeed());
         }
-        
-        $shuffler->setSeed($this->previewSession->getRandomizerSeed());
-        
-        return $shuffler;
+
+        return $this->randomGroup->shuffleArray(new GivenSeed($this->previewSession->getRandomizerSeed()));
     }
     
     protected function populateNotesPanel(ilTemplate $tpl, $notesPanelHTML)

--- a/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilObjQuestionPoolGUI.php
@@ -92,6 +92,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
         $ilDB = $DIC['ilDB'];
         $ilPluginAdmin = $DIC['ilPluginAdmin'];
         $ilias = $DIC['ilias'];
+        $randomGroup = $DIC->refinery()->random();
         
         $writeAccess = $ilAccess->checkAccess("write", "", $_GET["ref_id"]);
         
@@ -162,7 +163,7 @@ class ilObjQuestionPoolGUI extends ilObjectGUI implements ilCtrlBaseClassInterfa
                 $this->ctrl->saveParameter($this, "q_id");
 
                 require_once 'Modules/TestQuestionPool/classes/class.ilAssQuestionPreviewGUI.php';
-                $gui = new ilAssQuestionPreviewGUI($this->ctrl, $this->tabs_gui, $this->tpl, $this->lng, $ilDB, $ilUser);
+                $gui = new ilAssQuestionPreviewGUI($this->ctrl, $this->tabs_gui, $this->tpl, $this->lng, $ilDB, $ilUser, $randomGroup);
                 
                 $gui->initQuestion((int) $_GET['q_id'], $this->object->getId());
                 $gui->initPreviewSettings($this->object->getRefId());

--- a/Modules/TestQuestionPool/classes/export/qti12/class.assClozeTestExport.php
+++ b/Modules/TestQuestionPool/classes/export/qti12/class.assClozeTestExport.php
@@ -1,6 +1,8 @@
 <?php
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Refinery\Random\Group as RandomGroup;
+
 include_once "./Modules/TestQuestionPool/classes/export/qti12/class.assQuestionExport.php";
 
 /**
@@ -14,6 +16,17 @@ include_once "./Modules/TestQuestionPool/classes/export/qti12/class.assQuestionE
 */
 class assClozeTestExport extends assQuestionExport
 {
+    private RandomGroup $randomGroup;
+
+    public function __construct($object)
+    {
+        global $DIC;
+
+        parent::__construct($object);
+
+        $this->randomGroup = $DIC->refinery()->random();
+    }
+
     /**
     * Returns a QTI xml representation of the question
     *
@@ -144,7 +157,7 @@ class assClozeTestExport extends assQuestionExport
                         $a_xml_writer->xmlStartTag("render_choice", $attrs);
 
                         // add answers
-                        foreach ($gap->getItems(new ilDeterministicArrayElementProvider()) as $answeritem) {
+                        foreach ($gap->getItems($this->randomGroup->dontShuffle()) as $answeritem) {
                             $attrs = array(
                                 "ident" => $answeritem->getOrder()
                             );
@@ -249,7 +262,7 @@ class assClozeTestExport extends assQuestionExport
             $gap = $this->object->getGap($i);
             switch ($gap->getType()) {
                 case CLOZE_SELECT:
-                    foreach ($gap->getItems(new ilDeterministicArrayElementProvider()) as $answer) {
+                    foreach ($gap->getItems($this->randomGroup->dontShuffle()) as $answer) {
                         $attrs = array(
                             "continue" => "Yes"
                         );
@@ -280,7 +293,7 @@ class assClozeTestExport extends assQuestionExport
                     break;
                 case CLOZE_NUMERIC:
                 case CLOZE_TEXT:
-                    foreach ($gap->getItems(new ilDeterministicArrayElementProvider()) as $answer) {
+                    foreach ($gap->getItems($this->randomGroup->dontShuffle()) as $answer) {
                         $attrs = array(
                             "continue" => "Yes"
                         );

--- a/Modules/TestQuestionPool/classes/feedback/class.ilAssClozeTestFeedback.php
+++ b/Modules/TestQuestionPool/classes/feedback/class.ilAssClozeTestFeedback.php
@@ -1,6 +1,8 @@
 <?php
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Refinery\Random\Group as RandomGroup;
+
 require_once 'Modules/TestQuestionPool/classes/feedback/class.ilAssMultiOptionQuestionFeedback.php';
 
 /**
@@ -46,7 +48,7 @@ class ilAssClozeTestFeedback extends ilAssMultiOptionQuestionFeedback
     {
         $answers = array();
         
-        foreach ($gap->getItems(new ilDeterministicArrayElementProvider()) as $item) {
+        foreach ($gap->getItems($this->randomGroup()->dontShuffle()) as $item) {
             $answers[] = '"' . $item->getAnswertext() . '"';
         }
         
@@ -191,7 +193,7 @@ class ilAssClozeTestFeedback extends ilAssMultiOptionQuestionFeedback
 
     protected function completeFbPropsForTextGap(ilRadioOption $fbModeOpt, assClozeGap $gap, int $gapIndex) : void
     {
-        foreach ($gap->getItems(new ilDeterministicArrayElementProvider()) as $answerIndex => $item) {
+        foreach ($gap->getItems($this->randomGroup()->dontShuffle()) as $answerIndex => $item) {
             $propertyLabel = $this->questionOBJ->prepareTextareaOutput(
                 $this->buildTextGapGivenAnswerFeedbackLabel($gapIndex, $item),
                 true
@@ -235,7 +237,7 @@ class ilAssClozeTestFeedback extends ilAssMultiOptionQuestionFeedback
     
     protected function completeFbPropsForSelectGap(ilRadioOption $fbModeOpt, assClozeGap $gap, int $gapIndex) : void
     {
-        foreach ($gap->getItems(new ilDeterministicArrayElementProvider()) as $optIndex => $item) {
+        foreach ($gap->getItems($this->randomGroup()->dontShuffle()) as $optIndex => $item) {
             $propertyLabel = $this->questionOBJ->prepareTextareaOutput(
                 $this->buildSelectGapOptionFeedbackLabel($gapIndex, $item),
                 true
@@ -397,7 +399,7 @@ class ilAssClozeTestFeedback extends ilAssMultiOptionQuestionFeedback
     
     protected function initFbPropsForTextGap(ilPropertyFormGUI $form, assClozeGap $gap, int $gapIndex) : void
     {
-        foreach ($gap->getItems(new ilDeterministicArrayElementProvider()) as $answerIndex => $item) {
+        foreach ($gap->getItems($this->randomGroup()->dontShuffle()) as $answerIndex => $item) {
             $value = $this->getSpecificAnswerFeedbackFormValue($gapIndex, $answerIndex);
             $postVar = $this->buildPostVarForFbFieldPerGapAnswers($gapIndex, $answerIndex);
             $form->getItemByPostVar($postVar)->setValue($value);
@@ -414,7 +416,7 @@ class ilAssClozeTestFeedback extends ilAssMultiOptionQuestionFeedback
     
     protected function initFbPropsForSelectGap(ilPropertyFormGUI $form, assClozeGap $gap, int $gapIndex) : void
     {
-        foreach ($gap->getItems(new ilDeterministicArrayElementProvider()) as $optIndex => $item) {
+        foreach ($gap->getItems($this->randomGroup()->dontShuffle()) as $optIndex => $item) {
             $value = $this->getSpecificAnswerFeedbackFormValue($gapIndex, $optIndex);
             $postVar = $this->buildPostVarForFbFieldPerGapAnswers($gapIndex, $optIndex);
             $form->getItemByPostVar($postVar)->setValue($value);
@@ -514,7 +516,7 @@ class ilAssClozeTestFeedback extends ilAssMultiOptionQuestionFeedback
     
     protected function saveFbPropsForTextGap(ilPropertyFormGUI $form, assClozeGap $gap, int $gapIndex) : void
     {
-        foreach ($gap->getItems(new ilDeterministicArrayElementProvider()) as $answerIndex => $item) {
+        foreach ($gap->getItems($this->randomGroup()->dontShuffle()) as $answerIndex => $item) {
             $postVar = $this->buildPostVarForFbFieldPerGapAnswers($gapIndex, $answerIndex);
             $value = $form->getItemByPostVar($postVar)->getValue();
             $this->saveSpecificAnswerFeedbackContent(
@@ -546,7 +548,7 @@ class ilAssClozeTestFeedback extends ilAssMultiOptionQuestionFeedback
     
     protected function saveFbPropsForSelectGap(ilPropertyFormGUI $form, assClozeGap $gap, int $gapIndex) : void
     {
-        foreach ($gap->getItems(new ilDeterministicArrayElementProvider()) as $optIndex => $item) {
+        foreach ($gap->getItems($this->randomGroup()->dontShuffle()) as $optIndex => $item) {
             $postVar = $this->buildPostVarForFbFieldPerGapAnswers($gapIndex, $optIndex);
             $value = $form->getItemByPostVar($postVar)->getValue();
             $this->saveSpecificAnswerFeedbackContent(
@@ -792,7 +794,7 @@ class ilAssClozeTestFeedback extends ilAssMultiOptionQuestionFeedback
                     return self::FB_TEXT_GAP_EMPTY_INDEX;
                 }
 
-                $items = $gap->getItems(new ilDeterministicArrayElementProvider());
+                $items = $gap->getItems($this->randomGroup()->dontShuffle());
 
                 foreach ($items as $answerIndex => $answer) {
                     /* @var assAnswerCloze $answer */
@@ -821,7 +823,7 @@ class ilAssClozeTestFeedback extends ilAssMultiOptionQuestionFeedback
 
                 /* @var assAnswerCloze $item */
 
-                $item = current($gap->getItems(new ilDeterministicArrayElementProvider()));
+                $item = current($gap->getItems($this->randomGroup()->dontShuffle()));
 
                 if ($answerValue == $item->getAnswertext()) {
                     return self::FB_NUMERIC_GAP_VALUE_HIT_INDEX;
@@ -849,5 +851,12 @@ class ilAssClozeTestFeedback extends ilAssMultiOptionQuestionFeedback
                     return self::FB_NUMERIC_GAP_TOO_HIGH_INDEX;
                 //}
         }
+    }
+
+    private function randomGroup() : RandomGroup
+    {
+        global $DIC;
+
+        return $DIC->refinery()->random();
     }
 }

--- a/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeValidator.php
+++ b/Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/ilAssLacCompositeValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+use ILIAS\Refinery\Random\Group as RandomGroup;
+
 require_once "Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Expressions/ilAssLacResultOfAnswerOfQuestionExpression.php";
 require_once "Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Exception/ilAssLacExpressionNotSupportedByQuestion.php";
 require_once "Modules/TestQuestionPool/classes/questions/LogicalAnswerCompare/Exception/ilAssLacQuestionNotExist.php";
@@ -29,12 +31,17 @@ class ilAssLacCompositeValidator
      */
     protected $object_loader;
 
+    private RandomGroup $randomGroup;
+
     /**
      * @param ilAssLacQuestionProvider $object_loader
      */
     public function __construct($object_loader)
     {
+        global $DIC;
+
         $this->object_loader = $object_loader;
+        $this->randomGroup = $DIC->refinery()->random();
     }
 
     public function validate(ilAssLacAbstractComposite $composite)
@@ -240,6 +247,6 @@ class ilAssLacCompositeValidator
     
     protected function getNonShuffler()
     {
-        return new ilDeterministicArrayElementProvider();
+        return $this->randomGroup->dontShuffle();
     }
 }

--- a/Modules/TestQuestionPool/test/assBaseTestCase.php
+++ b/Modules/TestQuestionPool/test/assBaseTestCase.php
@@ -2,6 +2,8 @@
 /* Copyright (c) 1998-2018 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 use PHPUnit\Framework\TestCase;
+use ILIAS\Refinery\Factory as RefineryFactory;
+use ILIAS\Refinery\Random\Group as RandomGroup;
 
 /**
  * Class assBaseTestCase
@@ -47,6 +49,10 @@ abstract class assBaseTestCase extends TestCase
         $rbacsystem_mock = $this->createMock('ilRbacSystem', array(), array(), '', false);
         $DIC['rbacsystem'] = $rbacsystem_mock;
         $GLOBALS['rbacsystem'] = $rbacsystem_mock;
+
+        $refineryMock = $this->getMockBuilder(RefineryFactory::class)->disableOriginalConstructor()->getMock();
+        $refineryMock->expects(self::any())->method('random')->willReturn($this->getMockBuilder(RandomGroup::class)->getMock());
+        $DIC['refinery'] = $refineryMock;
 
         parent::setUp();
     }

--- a/Modules/TestQuestionPool/test/assClozeGapTest.php
+++ b/Modules/TestQuestionPool/test/assClozeGapTest.php
@@ -1,6 +1,8 @@
 <?php
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
+use ILIAS\Refinery\Transformation;
+
 /**
 * Unit tests
 *
@@ -25,7 +27,6 @@ class assClozeGapTest extends assBaseTestCase
         parent::setUp();
 
         require_once './Services/Utilities/classes/class.ilUtil.php';
-        require_once './Services/Randomization/classes/class.ilArrayElementShuffler.php';
         $util_mock = $this->createMock('ilUtil', array('stripSlashes'), array(), '', false);
         $util_mock->expects($this->any())->method('stripSlashes')->will($this->returnArgument(0));
         $this->setGlobalVariable('ilUtils', $util_mock);
@@ -99,11 +100,14 @@ class assClozeGapTest extends assBaseTestCase
             'Meyer', 'Jansen', 'Heyser', 'Becker');
         $instance->items = $the_unexpected;
         $instance->setShuffle(true);
-        
-        $actual = $instance->getItems(new ilArrayElementShuffler);
+        $theExpected = ['hua', 'haaa', 'some random values'];
+
+        $transformationMock = $this->getMockBuilder(Transformation::class)->getMock();
+        $transformationMock->expects(self::once())->method('transform')->with($the_unexpected)->willReturn($theExpected);
+        $actual = $instance->getItems($transformationMock);
 
         // Assert
-        $this->assertNotEquals($the_unexpected, $actual);
+        $this->assertEquals($theExpected, $actual);
     }
     
     public function test_addGetItem_shouldReturnValueUnchanged()
@@ -201,7 +205,9 @@ class assClozeGapTest extends assBaseTestCase
         $instance->addItem($item2);
         $instance->addItem($item3);
         $instance->addItem($item4);
-        $actual = $instance->getItems(new ilArrayElementShuffler);
+        $transformationMock = $this->getMockBuilder(Transformation::class)->getMock();
+        $transformationMock->expects(self::never())->method('transform');
+        $actual = $instance->getItems($transformationMock);
 
         // Assert
         $this->assertEquals($expected, $actual);
@@ -214,38 +220,31 @@ class assClozeGapTest extends assBaseTestCase
         $instance = new assClozeGap(0); // 0 - text gap
         $instance->setShuffle(true);
         require_once './Modules/TestQuestionPool/classes/class.assAnswerCloze.php';
-        $item1 = new assAnswerCloze('Bert', 1.0, 0);
-        $item2 = new assAnswerCloze('Fred', 1.0, 1);
-        $item3 = new assAnswerCloze('Karl', 1.0, 2);
-        $item4 = new assAnswerCloze('Esther', 1.0, 3);
-        $item5 = new assAnswerCloze('Herbert', 1.0, 4);
-        $item6 = new assAnswerCloze('Karina', 1.0, 5);
-        $item7 = new assAnswerCloze('Helmut', 1.0, 6);
-        $item8 = new assAnswerCloze('Kerstin', 1.0, 7);
-        $expected = array($item1, $item2, $item3, $item4, $item5, $item6, $item7, $item8);
+        $expected = [
+            new assAnswerCloze('Bert', 1.0, 0),
+            new assAnswerCloze('Fred', 1.0, 1),
+            new assAnswerCloze('Karl', 1.0, 2),
+            new assAnswerCloze('Esther', 1.0, 3),
+            new assAnswerCloze('Herbert', 1.0, 4),
+            new assAnswerCloze('Karina', 1.0, 5),
+            new assAnswerCloze('Helmut', 1.0, 6),
+            new assAnswerCloze('Kerstin', 1.0, 7),
+        ];
+
+        $shuffledArray = ['some shuffled array', 'these values dont matter'];
 
         // Act
-        $instance->addItem($item1);
-        $instance->addItem($item2);
-        $instance->addItem($item3);
-        $instance->addItem($item4);
-        $instance->addItem($item5);
-        $instance->addItem($item6);
-        $instance->addItem($item7);
-        $instance->addItem($item8);
-        $actual = $instance->getItems(new ilArrayElementShuffler);
+        foreach ($expected as $item) {
+            $instance->addItem($item);
+        }
+
+        $transformationMock = $this->getMockBuilder(Transformation::class)->getMock();
+        $transformationMock->expects(self::once())->method('transform')->with($expected)->willReturn($shuffledArray);
+        $actual = $instance->getItems($transformationMock);
 
         // Assert
-        $this->assertTrue(is_array($actual));
-        $this->assertTrue(in_array($item1, $actual));
-        $this->assertTrue(in_array($item2, $actual));
-        $this->assertTrue(in_array($item3, $actual));
-        $this->assertTrue(in_array($item4, $actual));
-        $this->assertTrue(in_array($item5, $actual));
-        $this->assertTrue(in_array($item6, $actual));
-        $this->assertTrue(in_array($item7, $actual));
-        $this->assertTrue(in_array($item8, $actual));
-        $this->assertNotEquals($expected, $actual);
+
+        $this->assertEquals($shuffledArray, $actual);
     }
 
     public function test_getItemsRaw_shouldReturnItemsAdded()
@@ -527,7 +526,7 @@ class assClozeGapTest extends assBaseTestCase
         $expected = 'Esther';
 
         // Act
-        $actual = $instance->getBestSolutionOutput(new ilArrayElementShuffler);
+        $actual = $instance->getBestSolutionOutput($this->getDummyTransformationMock());
 
         // Assert
         $this->assertEquals($expected, $actual);
@@ -563,7 +562,7 @@ class assClozeGapTest extends assBaseTestCase
         $expected2 = 'Esther or Karl';
 
         // Act
-        $actual = $instance->getBestSolutionOutput(new ilArrayElementShuffler);
+        $actual = $instance->getBestSolutionOutput($this->getDummyTransformationMock());
 
         // Assert
         $this->assertTrue(($actual == $expected1) || ($actual == $expected2));
@@ -597,7 +596,7 @@ class assClozeGapTest extends assBaseTestCase
         $expected = 100;
 
         // Act
-        $actual = $instance->getBestSolutionOutput(new ilArrayElementShuffler);
+        $actual = $instance->getBestSolutionOutput($this->getDummyTransformationMock());
 
         // Assert
         $this->assertEquals($expected, $actual);
@@ -631,9 +630,19 @@ class assClozeGapTest extends assBaseTestCase
         $expected = '';
 
         // Act
-        $actual = $instance->getBestSolutionOutput(new ilArrayElementShuffler);
+        $actual = $instance->getBestSolutionOutput($this->getDummyTransformationMock());
 
         // Assert
         $this->assertEquals($expected, $actual);
+    }
+
+    private function getDummyTransformationMock() : Transformation
+    {
+        $transformationMock = $this->getMockBuilder(Transformation::class)->getMock();
+        $transformationMock->expects(self::any())->method('transform')->willReturnCallback(static function (array $array) {
+            return $array;
+        });
+
+        return $transformationMock;
     }
 }

--- a/Modules/TestQuestionPool/test/assClozeSelectGapTest.php
+++ b/Modules/TestQuestionPool/test/assClozeSelectGapTest.php
@@ -3,6 +3,8 @@
 
 require_once __DIR__ . "/assBaseTestCase.php";
 
+use ILIAS\Refinery\Transformation;
+
 /**
 * Unit tests
 *
@@ -54,10 +56,12 @@ class assClozeSelectGapTest extends assBaseTestCase
         // Arrange
         require_once './Modules/TestQuestionPool/classes/class.assClozeSelectGap.php';
         $instance = new assClozeSelectGap(1); // 1 - select gap
-        $expected = array(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20);
+        $expected = ['shfksdfs', 'sfsdf', 'sdfsdfdf'];
 
-        $actual = $instance->getItems(new ilArrayElementShuffler());
-        $this->assertNotEquals($expected, $actual);
+        $transformationMock = $this->getMockBuilder(Transformation::class)->getMock();
+        $transformationMock->expects(self::once())->method('transform')->willReturn($expected);
+        $actual = $instance->getItems($transformationMock);
+        $this->assertEquals($expected, $actual);
     }
 
     public function test_getItemswithShuffle_shouldReturnShuffledItems()
@@ -89,9 +93,9 @@ class assClozeSelectGapTest extends assBaseTestCase
         $sequence = [$item1, $item3, $item2, $item4, $item5, $item6, $item7, $item8];
         $expectedSequence = array_reverse($sequence);
 
-        $randomElmProvider = $this->getMockBuilder(ilRandomArrayElementProvider::class)->getMock();
+        $randomElmProvider = $this->getMockBuilder(Transformation::class)->getMock();
         $randomElmProvider->expects($this->once())
-                          ->method('shuffle')
+                          ->method('transform')
                           ->with($sequence)
                           ->willReturn($expectedSequence);
 
@@ -118,7 +122,11 @@ class assClozeSelectGapTest extends assBaseTestCase
         $instance->setType(false);
 
         $expected = array($item1, $item2, $item3, $item4);
-        $actual = $instance->getItems(new ilDeterministicArrayElementProvider());
+        $transformationMock = $this->getMockBuilder(Transformation::class)->getMock();
+        $transformationMock->expects(self::once())->method('transform')->willReturnCallback(function ($value) {
+            return $value;
+        });
+        $actual = $instance->getItems($transformationMock);
 
         $this->assertEquals($expected, $actual);
     }

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
 		"ramsey/uuid": "^3.8",
 		"enshrined/svg-sanitize": "^0.13.0",
 		"guzzlehttp/guzzle": "^6.3",
-		"simplesamlphp/simplesamlphp": "^1.18"
+		"simplesamlphp/simplesamlphp": "^1.18",
+		"seld/jsonlint": "^1.8"
 	},
 	"require-dev": {
 		"mikey179/vfsstream": "^1.6",
@@ -396,6 +397,16 @@
 			"last_update_by" : "Alex Killing <killing@leifos.de>",
 			"approved-by": "see security issue 20339",
 			"approved-date": "2017-04-05"
+		},
+		"seld/jsonlint" : {
+			"source" : "https://github.com/Seldaek/jsonlint",
+			"used_version" : "v1.8.3",
+			"wrapped_by" : null,
+			"added_by" : "Daniel Weise <daniel.weise@concepts-and-training.de>",
+			"last_update" : "2021-11-18",
+			"last_update_by" : "Daniel Weise <daniel.weise@concepts-and-training.de>",
+			"approved-by": "Jour Fix",
+			"approved-date": "2021-11-29"
 		},
 		"patches": {
 			"tecnickcom/tcpdf": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50df347b74ce2011c4ac32f79dd0df6b",
+    "content-hash": "f8ec8daf049be704ddf00e48dc0ba1c0",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -2728,6 +2728,69 @@
                 "xml"
             ],
             "time": "2020-10-03T10:08:14+00:00"
+        },
+        {
+            "name": "seld/jsonlint",
+            "version": "1.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
+                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/jsonlint/issues",
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.8.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-11T09:19:24+00:00"
         },
         {
             "name": "simplesamlphp/composer-module-installer",

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -16649,6 +16649,8 @@ prg#:#will_not_modify_validity_on_non_successful_progress#:#Gültigkeit kann nur
 prg#:#status_unchanged#:#Status unverändert
 common#:#file_system_clean_temp_dir_cron#:#Temporäres Verzeichnis aufräumen
 common#:#file_system_clean_temp_dir_cron_info#:#Dieser Job räumt das ILIAS temp-Verzeichnis auf und löscht von Dateien, welche älter als 10 Tage sind. Damit wird einer Anhäufung ungenutzter Dateien und damit einem erhöhten Speicherplatzverbrauch des temp-Verzeichnisses entgegengewirkt.
+common#:#actions_for#:#Aktionen für %s
 violation#:#not_a_string#:#Wert ist keine Zeichenkette
 common#:#actions_for#:#Aktionen für %s
 validation#:#not_greater_than_or_equal#:#Der Wert ist nicht größer oder gleich '%s'.
+validation#:#not_an_array#:#Wert ist kein Feld

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -2401,7 +2401,6 @@ cntr#:#cntr_view_sessions#:#Sitzungsansicht
 cntr#:#cntr_view_simple#:#Einfache Liste
 cntr#:#container_import_zip_file_invalid#:#Die hochgeladene Datei ist kein gültiger ILIAS Export. Um Verzeichnisstrukturen hochzuladen benutzen Sie bitte ein Datei-Objekt.
 cntr#:#edit_questions#:#Fragen bearbeiten
-common#:#3rd_party_software#:#Drittanbieter-Software
 common#:#absolute_path#:#Absoluter Pfad
 common#:#accept_usr_agreement#:#Nutzungsvereinbarung akzeptieren?
 common#:#withdraw_consent_header#:#Einverständnis zur Nutzungsvereinbarung widerrufen
@@ -3290,6 +3289,7 @@ common#:#hint#:#Hinweis
 common#:#hist_lm_delete_pg#:#Seite "%1" [%2] wurde gelöscht.
 common#:#hist_lm_delete_st#:#Kapitel "%1" [%2] wurde gelöscht.
 common#:#hist_lm_pg_create#:#Seite erstellt.
+common#:#hist_lm_pg_update#:#Seite geändert.
 common#:#hist_lm_st_create#:#Kapitel erstellt.
 common#:#hist_webr_add#:#Neuer Weblink angelegt mit Titel: "%1"
 common#:#hist_webr_delete#:#Weblink wurde gelöscht. Titel: "%1"

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -1996,7 +1996,6 @@ cntr#:#cntr_view_info_sessions#:#This content presentation groups all sessions f
 cntr#:#cntr_view_info_simple#:#This content presentation lists all items in one block.
 cntr#:#cntr_view_sessions#:#Sessions View
 cntr#:#cntr_view_simple#:#Simple View
-common#:#3rd_party_software#:#3rd party software
 common#:#absolute_path#:#Absolute Path
 common#:#accept_usr_agreement#:#Accept terms of service?
 common#:#withdraw_consent_header#:#Revoke acceptance to terms of service
@@ -2829,6 +2828,7 @@ common#:#hint#:#Hint
 common#:#hist_lm_delete_pg#:#Page "%1" [%2] has been deleted.
 common#:#hist_lm_delete_st#:#Chapter "%1" [%2] has been deleted.
 common#:#hist_lm_pg_create#:#Page created.
+common#:#hist_lm_pg_update#:#Page changed.
 common#:#hist_lm_st_create#:#Chapter created.
 common#:#hist_webr_add#:#Added new Weblink with title: "%1"
 common#:#hist_webr_delete#:#Deleted Weblink with title: "%1"

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -16651,6 +16651,8 @@ prg#:#will_not_modify_validity_on_non_successful_progress#:#Can change only when
 prg#:#status_unchanged#:#Status unchanged
 common#:#file_system_clean_temp_dir_cron#:#Clean temp directory
 common#:#file_system_clean_temp_dir_cron_info#:#This job cleans the ILIAS temp-directory of files, which are older than 10 days. This counteracts the accumulation of unused files and therefore prevents an increased use of disk space by the temp directory.
+common#:#actions_for#:#Actions for %s
 violation#:#not_a_string#:#Given value is not a String
 common#:#actions_for#:#Actions for %s
 validation#:#not_greater_than_or_equal#:#The value is not greater than or equal '%s'.
+validation#:#not_an_array#:#Given value is not an array

--- a/setup/cli.php
+++ b/setup/cli.php
@@ -144,6 +144,7 @@ function build_container_for_setup(string $executed_in_directory) : \Pimple\Cont
 
     $c["config_reader"] = function ($c) use ($executed_in_directory) {
         return new \ILIAS\Setup\CLI\ConfigReader(
+            $c["json.parser"],
             $executed_in_directory
         );
     };
@@ -154,6 +155,10 @@ function build_container_for_setup(string $executed_in_directory) : \Pimple\Cont
 
     $c["plugin_raw_reader"] = function ($c) {
         return new \ilPluginRawReader();
+    };
+
+    $c["json.parser"] = function ($c) {
+        return new \Seld\JsonLint\JsonParser();
     };
 
     return $c;

--- a/src/Refinery/DeriveApplyToFromTransform.php
+++ b/src/Refinery/DeriveApplyToFromTransform.php
@@ -5,6 +5,8 @@
 namespace ILIAS\Refinery;
 
 use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
 
 /**
  * @author  Niels Theen <ntheen@databay.de>
@@ -20,12 +22,12 @@ trait DeriveApplyToFromTransform
 
     public function applyTo(Result $result) : Result
     {
-        try {
-            $value = $this->transform($result->value());
-        } catch (\Exception $exception) {
-            return new Result\Error($exception);
-        }
-
-        return new Result\Ok($value);
+        return $result->then(function ($value) use ($result) : Result {
+            try {
+                return new Ok($this->transform($result->value()));
+            } catch (\Exception $exception) {
+                return new Error($exception);
+            }
+        });
     }
 }

--- a/src/Refinery/DeriveApplyToFromTransform.php
+++ b/src/Refinery/DeriveApplyToFromTransform.php
@@ -24,7 +24,7 @@ trait DeriveApplyToFromTransform
     {
         return $result->then(function ($value) use ($result) : Result {
             try {
-                return new Ok($this->transform($result->value()));
+                return new Ok($this->transform($value));
             } catch (\Exception $exception) {
                 return new Error($exception);
             }

--- a/src/Refinery/DeriveApplyToFromTransform.php
+++ b/src/Refinery/DeriveApplyToFromTransform.php
@@ -22,7 +22,7 @@ trait DeriveApplyToFromTransform
 
     public function applyTo(Result $result) : Result
     {
-        return $result->then(function ($value) use ($result) : Result {
+        return $result->then(function ($value) : Result {
             try {
                 return new Ok($this->transform($value));
             } catch (\Exception $exception) {

--- a/src/Refinery/Factory.php
+++ b/src/Refinery/Factory.php
@@ -7,6 +7,7 @@ namespace ILIAS\Refinery;
 use ILIAS\Refinery\In;
 use ILIAS\Refinery\To;
 use ILIAS\Refinery\ByTrying;
+use ILIAS\Refinery\Random\Group as RandomGroup;
 
 /**
  * @author  Niels Theen <ntheen@databay.de>
@@ -145,5 +146,10 @@ class Factory
     public function byTrying(array $transformations) : ByTrying
     {
         return new ByTrying($transformations, $this->dataFactory, $this->language);
+    }
+
+    public function random() : RandomGroup
+    {
+        return new RandomGroup();
     }
 }

--- a/src/Refinery/IdentityTransformation.php
+++ b/src/Refinery/IdentityTransformation.php
@@ -3,9 +3,8 @@
 /**
  * @author  Lukas Scharmer <lscharmer@databay.de>
  */
-namespace ILIAS\Refinery\Random\Transformation;
+namespace ILIAS\Refinery;
 
-use ILIAS\Refinery\Transformation;
 use ILIAS\Data\Result;
 use ILIAS\Data\Result\Ok;
 use ILIAS\Refinery\DeriveInvokeFromTransform;

--- a/src/Refinery/IdentityTransformation.php
+++ b/src/Refinery/IdentityTransformation.php
@@ -8,51 +8,18 @@ namespace ILIAS\Refinery;
 use ILIAS\Data\Result;
 use ILIAS\Data\Result\Ok;
 use ILIAS\Refinery\DeriveInvokeFromTransform;
+use ILIAS\Refinery\DeriveApplyToFromTransform;
 
 class IdentityTransformation implements Transformation
 {
     use DeriveInvokeFromTransform;
+    use DeriveApplyToFromTransform;
 
     /**
      * @throws \InvalidArgumentException
      */
     public function transform($from)
     {
-        return $this->transformResult($from)->value();
-    }
-
-    /**
-     * @return Result
-     */
-    public function applyTo(Result $result) : Result
-    {
-        return $result->then(function ($from) {
-            return $this->transformResult($from);
-        });
-    }
-
-    /**
-     * @return Result
-     */
-    protected function validate($from) : Result
-    {
-        return new Ok($from);
-    }
-
-    protected function saveTransform($value)
-    {
-        return $value;
-    }
-
-    /**
-     * Same as transform but returns a Result instead of an exception.
-     *
-     * @return Result
-     */
-    private function transformResult($from) : Result
-    {
-        return $this->validate($from)->map(function ($from) {
-            return $this->saveTransform($from);
-        });
+        return $from;
     }
 }

--- a/src/Refinery/Random/Group.php
+++ b/src/Refinery/Random/Group.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+/**
+ * @author  Lukas Scharmer <lscharmer@databay.de>
+ */
+namespace ILIAS\Refinery\Random;
+
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\Random\Transformation\ShuffleTransformation;
+use ILIAS\Refinery\Random\Seed\Seed;
+use ILIAS\Refinery\Random\Transformation\IdentityTransformation;
+
+class Group
+{
+    /**
+     * Get a transformation which will shuffle a given array.
+     * Only arrays can be supplied to the transformation.
+     *
+     * The transformation will be shuffled with the given $seed.
+     *
+     * !! BEWARE OF THE SIDE EFFECT. This Transformation is not SIde Effect free !!
+     */
+    public function shuffleArray(Seed $seed) : Transformation
+    {
+        return new ShuffleTransformation($seed);
+    }
+
+    /**
+     * Get a transformation which will return the given value as is.
+     * Everything can be supplied to the transformation.
+     */
+    public function dontShuffle() : Transformation
+    {
+        return new IdentityTransformation();
+    }
+}

--- a/src/Refinery/Random/Group.php
+++ b/src/Refinery/Random/Group.php
@@ -8,7 +8,7 @@ namespace ILIAS\Refinery\Random;
 use ILIAS\Refinery\Transformation;
 use ILIAS\Refinery\Random\Transformation\ShuffleTransformation;
 use ILIAS\Refinery\Random\Seed\Seed;
-use ILIAS\Refinery\Random\Transformation\IdentityTransformation;
+use ILIAS\Refinery\IdentityTransformation;
 
 class Group
 {
@@ -19,6 +19,7 @@ class Group
      * The transformation will be shuffled with the given $seed.
      *
      * !! BEWARE OF THE SIDE EFFECT. This Transformation is not Side Effect free !!
+     * The internal state of the PRNG will be advanced on every usage.
      */
     public function shuffleArray(Seed $seed) : Transformation
     {

--- a/src/Refinery/Random/Group.php
+++ b/src/Refinery/Random/Group.php
@@ -18,7 +18,7 @@ class Group
      *
      * The transformation will be shuffled with the given $seed.
      *
-     * !! BEWARE OF THE SIDE EFFECT. This Transformation is not SIde Effect free !!
+     * !! BEWARE OF THE SIDE EFFECT. This Transformation is not Side Effect free !!
      */
     public function shuffleArray(Seed $seed) : Transformation
     {

--- a/src/Refinery/Random/Seed/GivenSeed.php
+++ b/src/Refinery/Random/Seed/GivenSeed.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/**
+ * @author  Lukas Scharmer <lscharmer@databay.de>
+ */
+namespace ILIAS\Refinery\Random\Seed;
+
+class GivenSeed implements Seed
+{
+    private int $seed;
+
+    public function __construct(int $seed)
+    {
+        $this->seed = $seed;
+    }
+
+    public function seedRandomGenerator() : void
+    {
+        mt_srand($this->seed);
+    }
+}

--- a/src/Refinery/Random/Seed/RandomSeed.php
+++ b/src/Refinery/Random/Seed/RandomSeed.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+/**
+ * @author  Lukas Scharmer <lscharmer@databay.de>
+ */
+namespace ILIAS\Refinery\Random\Seed;
+
+class RandomSeed extends GivenSeed
+{
+    public function __construct()
+    {
+        parent::__construct($this->createSeed());
+    }
+
+    public function createSeed() : int
+    {
+        $array = explode(' ', microtime());
+        $seed = $array[1] + ($array[0] * 100000);
+
+        return $seed;
+    }
+}

--- a/src/Refinery/Random/Seed/Seed.php
+++ b/src/Refinery/Random/Seed/Seed.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+/**
+ * @author  Lukas Scharmer <lscharmer@databay.de>
+ */
+namespace ILIAS\Refinery\Random\Seed;
+
+interface Seed
+{
+    public function seedRandomGenerator() : void;
+}

--- a/src/Refinery/Random/Transformation/IdentityTransformation.php
+++ b/src/Refinery/Random/Transformation/IdentityTransformation.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+/**
+ * @author  Lukas Scharmer <lscharmer@databay.de>
+ */
+namespace ILIAS\Refinery\Random\Transformation;
+
+use ILIAS\Refinery\Transformation;
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Refinery\DeriveInvokeFromTransform;
+
+class IdentityTransformation implements Transformation
+{
+    use DeriveInvokeFromTransform;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function transform($from)
+    {
+        return $this->transformResult($from)->value();
+    }
+
+    /**
+     * @return Result
+     */
+    public function applyTo(Result $result) : Result
+    {
+        return $result->then(function ($from) {
+            return $this->transformResult($from);
+        });
+    }
+
+    /**
+     * @return Result
+     */
+    protected function validate($from) : Result
+    {
+        return new Ok($from);
+    }
+
+    protected function saveTransform($value)
+    {
+        return $value;
+    }
+
+    /**
+     * Same as transform but returns a Result instead of an exception.
+     *
+     * @return Result
+     */
+    private function transformResult($from) : Result
+    {
+        return $this->validate($from)->map(function ($from) {
+            return $this->saveTransform($from);
+        });
+    }
+}

--- a/src/Refinery/Random/Transformation/ShuffleTransformation.php
+++ b/src/Refinery/Random/Transformation/ShuffleTransformation.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+/**
+ * @author  Lukas Scharmer <lscharmer@databay.de>
+ */
+namespace ILIAS\Refinery\Random\Transformation;
+
+use ILIAS\Data\Result;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use ILIAS\Refinery\Random\Seed\Seed;
+
+/**
+ * !! BEWARE OF THE SIDE EFFECT. This Transformation is not Side Effect free !!
+ * Shuffling and seeding of the random generator is not side effect free and done when transforming a value.
+ * This class is an expection to the rule of the normally side effect free transformations.
+ */
+class ShuffleTransformation extends IdentityTransformation
+{
+    private Seed $seed;
+
+    public function __construct(Seed $seed)
+    {
+        $this->seed = $seed;
+    }
+
+    /**
+     * @return Result<array>
+     */
+    protected function validate($from) : Result
+    {
+        return is_array($from) ? new Ok($from) : new Error('I need an array');
+    }
+
+    /**
+     * @param array $array
+     * @return array
+     */
+    protected function saveTransform($array)
+    {
+        $this->seed->seedRandomGenerator();
+        \shuffle($array);
+
+        return $array;
+    }
+}

--- a/src/Refinery/Random/Transformation/ShuffleTransformation.php
+++ b/src/Refinery/Random/Transformation/ShuffleTransformation.php
@@ -9,11 +9,14 @@ use ILIAS\Data\Result;
 use ILIAS\Data\Result\Ok;
 use ILIAS\Data\Result\Error;
 use ILIAS\Refinery\Random\Seed\Seed;
+use ILIAS\Refinery\IdentityTransformation;
 
 /**
  * !! BEWARE OF THE SIDE EFFECT. This Transformation is not Side Effect free !!
  * Shuffling and seeding of the random generator is not side effect free and done when transforming a value.
- * This class is an expection to the rule of the normally side effect free transformations.
+ * This class is an exception to the rule of the normally side effect free transformations.
+ * @see https://github.com/ILIAS-eLearning/ILIAS/pull/476/files#diff-a6b45507ea92787f1788b74d31ba62162dd9b09f00e7a9dea804be783c09afecR8
+ * and https://github.com/ILIAS-eLearning/ILIAS/pull/1707/files#diff-cbb4c50b8e633da5c3461f5b4bdf0f29c11199213ae2c60788af66b885b6bb5e
  */
 class ShuffleTransformation extends IdentityTransformation
 {

--- a/src/Refinery/Random/Transformation/ShuffleTransformation.php
+++ b/src/Refinery/Random/Transformation/ShuffleTransformation.php
@@ -10,6 +10,10 @@ use ILIAS\Data\Result\Ok;
 use ILIAS\Data\Result\Error;
 use ILIAS\Refinery\Random\Seed\Seed;
 use ILIAS\Refinery\IdentityTransformation;
+use ILIAS\Refinery\Transformation;
+use ILIAS\Refinery\ConstraintViolationException;
+use ILIAS\Refinery\DeriveInvokeFromTransform;
+use ILIAS\Refinery\DeriveApplyToFromTransform;
 
 /**
  * !! BEWARE OF THE SIDE EFFECT. This Transformation is not Side Effect free !!
@@ -18,8 +22,11 @@ use ILIAS\Refinery\IdentityTransformation;
  * @see https://github.com/ILIAS-eLearning/ILIAS/pull/476/files#diff-a6b45507ea92787f1788b74d31ba62162dd9b09f00e7a9dea804be783c09afecR8
  * and https://github.com/ILIAS-eLearning/ILIAS/pull/1707/files#diff-cbb4c50b8e633da5c3461f5b4bdf0f29c11199213ae2c60788af66b885b6bb5e
  */
-class ShuffleTransformation extends IdentityTransformation
+class ShuffleTransformation implements Transformation
 {
+    use DeriveInvokeFromTransform;
+    use DeriveApplyToFromTransform;
+
     private Seed $seed;
 
     public function __construct(Seed $seed)
@@ -28,19 +35,14 @@ class ShuffleTransformation extends IdentityTransformation
     }
 
     /**
-     * @return Result<array>
-     */
-    protected function validate($from) : Result
-    {
-        return is_array($from) ? new Ok($from) : new Error('I need an array');
-    }
-
-    /**
-     * @param array $array
+     * @throws ConstraintViolationException
      * @return array
      */
-    protected function saveTransform($array)
+    public function transform($array)
     {
+        if (!is_array($array)) {
+            throw new ConstraintViolationException('not an array', 'not_an_array');
+        }
         $this->seed->seedRandomGenerator();
         \shuffle($array);
 

--- a/src/Setup/CLI/ConfigReader.php
+++ b/src/Setup/CLI/ConfigReader.php
@@ -11,16 +11,19 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Seld\JsonLint\JsonParser;
 
 /**
  * Read a json-formatted config from a file and overwrite some fields.
  */
 class ConfigReader
 {
+    protected JsonParser $json_parser;
     protected string $base_dir;
 
-    public function __construct(string $base_dir = null)
+    public function __construct(JsonParser $json_parser, string $base_dir = null)
     {
+        $this->json_parser = $json_parser;
         $this->base_dir = $base_dir ?? getcwd();
     }
 
@@ -41,7 +44,11 @@ class ConfigReader
                 "Config-file '$name' does not exist or is not readable."
             );
         }
-        $json = json_decode(file_get_contents($name), (bool) JSON_OBJECT_AS_ARRAY);
+        $json = $this->json_parser->parse(
+            file_get_contents($name),
+            JsonParser::PARSE_TO_ASSOC | JsonParser::DETECT_KEY_CONFLICTS
+        );
+
         if (!is_array($json)) {
             throw new \InvalidArgumentException(
                 "Could not find JSON-array in '$name'."

--- a/tests/Refinery/IdentityTransformationTest.php
+++ b/tests/Refinery/IdentityTransformationTest.php
@@ -8,7 +8,7 @@ namespace ILIAS\Tests\Refinery\Random\Transformation;
 use ILIAS\Data\NotOKException;
 use ILIAS\Data\Result\Ok;
 use ILIAS\Data\Result\Error;
-use ILIAS\Refinery\Random\Transformation\IdentityTransformation;
+use ILIAS\Refinery\IdentityTransformation;
 use PHPUnit\Framework\TestCase;
 
 class IdentityTransformationTest extends TestCase

--- a/tests/Refinery/Random/GroupTest.php
+++ b/tests/Refinery/Random/GroupTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @author  Lukas Scharmer <lscharmer@databay.de>
+ */
+namespace ILIAS\Tests\Refinery\Random;
+
+use ILIAS\Refinery\Random\Group;
+use ILIAS\Refinery\Transformation;
+use PHPUnit\Framework\TestCase;
+use ILIAS\Refinery\Random\Seed\Seed;
+use ILIAS\Refinery\Random\Transformation\ShuffleTransformation;
+use ILIAS\Refinery\Random\Transformation\IdentityTransformation;
+
+class GroupTest extends TestCase
+{
+    /**
+     * @var Group
+     */
+    private $group;
+
+    public function setUp() : void
+    {
+        $this->group = new Group();
+    }
+
+    public function testShuffle() : void
+    {
+        $mock = $this->getMockBuilder(Seed::class)->getMock();
+        $mock->expects(self::never())->method('seedRandomGenerator');
+        $instance = $this->group->shuffleArray($mock);
+        $this->assertInstanceOf(ShuffleTransformation::class, $instance);
+    }
+
+    public function testDontShuffle() : void
+    {
+        $instance = $this->group->dontShuffle();
+        $this->assertInstanceOf(IdentityTransformation::class, $instance);
+    }
+}

--- a/tests/Refinery/Random/GroupTest.php
+++ b/tests/Refinery/Random/GroupTest.php
@@ -10,7 +10,7 @@ use ILIAS\Refinery\Transformation;
 use PHPUnit\Framework\TestCase;
 use ILIAS\Refinery\Random\Seed\Seed;
 use ILIAS\Refinery\Random\Transformation\ShuffleTransformation;
-use ILIAS\Refinery\Random\Transformation\IdentityTransformation;
+use ILIAS\Refinery\IdentityTransformation;
 
 class GroupTest extends TestCase
 {

--- a/tests/Refinery/Random/Transformation/IdentityTransformationTest.php
+++ b/tests/Refinery/Random/Transformation/IdentityTransformationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @author  Lukas Scharmer <lscharmer@databay.de>
+ */
+namespace ILIAS\Tests\Refinery\Random\Transformation;
+
+use ILIAS\Data\NotOKException;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use ILIAS\Refinery\Random\Transformation\IdentityTransformation;
+use PHPUnit\Framework\TestCase;
+
+class IdentityTransformationTest extends TestCase
+{
+    public function testTransform() : void
+    {
+        $value = 'hejaaa';
+
+        $actual = (new IdentityTransformation())->transform($value);
+
+        $this->assertEquals($value, $actual);
+    }
+
+    public function testApplyToOk() : void
+    {
+        $value = ['im in an array'];
+        $result = (new IdentityTransformation())->applyTo(new Ok($value));
+        $this->assertInstanceOf(Ok::class, $result);
+        $this->assertEquals($value, $result->value());
+    }
+
+    public function testApplyToError() : void
+    {
+        $error = new Error('some error');
+        $result = (new IdentityTransformation())->applyTo($error);
+        $this->assertEquals($error, $result);
+    }
+}

--- a/tests/Refinery/Random/Transformation/ShuffleTransformationTest.php
+++ b/tests/Refinery/Random/Transformation/ShuffleTransformationTest.php
@@ -3,7 +3,7 @@
 /**
  * @author  Lukas Scharmer <lscharmer@databay.de>
  */
-namespace ILIAS\Tests\Refinery\Random\Transformation;
+namespace ILIAS\Tests\Refinery;
 
 use ILIAS\Refinery\Random\Transformation\ShuffleTransformation;
 use ILIAS\Refinery\Random\Seed\Seed;
@@ -16,12 +16,16 @@ class ShuffleTransformationTest extends TestCase
 {
     public function testTransformResultSuccess() : void
     {
-        $value = ['nrrrrg'];
+        $seed = 0;
+        $value = ['Donec', 'at', 'pede', 'Phasellus', 'purus', 'Nulla', 'facilisis', 'risus', 'a', 'rhoncus', 'fermentum', 'tellus', 'tellus', 'lacinia', 'purus', 'et', 'dictum', 'nunc', 'justo', 'sit', 'amet', 'elit'];
+        $expected = $this->shuffleWithSeed($value, $seed);
         $seedMock = $this->getMockBuilder(Seed::class)->getMock();
-        $seedMock->expects(self::once())->method('seedRandomGenerator');
+        $seedMock->expects(self::once())->method('seedRandomGenerator')->willReturnCallback(static function () use ($seed) : void {
+            \mt_srand($seed);
+        });
 
         $result = (new ShuffleTransformation($seedMock))->transform($value);
-        $this->assertEquals($value, $result);
+        $this->assertEquals($expected, $result);
     }
 
     public function testTransformResultFailure() : void
@@ -31,5 +35,13 @@ class ShuffleTransformationTest extends TestCase
         $seedMock->expects(self::never())->method('seedRandomGenerator');
 
         $result = (new ShuffleTransformation($seedMock))->transform('im no array');
+    }
+
+    private function shuffleWithSeed(array $array, int $seed) : array
+    {
+        \mt_srand($seed);
+        \shuffle($array);
+
+        return $array;
     }
 }

--- a/tests/Refinery/Random/Transformation/ShuffleTransformationTest.php
+++ b/tests/Refinery/Random/Transformation/ShuffleTransformationTest.php
@@ -11,6 +11,7 @@ use ILIAS\Data\NotOKException;
 use ILIAS\Data\Result\Ok;
 use ILIAS\Data\Result\Error;
 use PHPUnit\Framework\TestCase;
+use ILIAS\Refinery\ConstraintViolationException;
 
 class ShuffleTransformationTest extends TestCase
 {
@@ -30,7 +31,7 @@ class ShuffleTransformationTest extends TestCase
 
     public function testTransformResultFailure() : void
     {
-        $this->expectException(NotOKException::class);
+        $this->expectException(ConstraintViolationException::class);
         $seedMock = $this->getMockBuilder(Seed::class)->getMock();
         $seedMock->expects(self::never())->method('seedRandomGenerator');
 

--- a/tests/Refinery/Random/Transformation/ShuffleTransformationTest.php
+++ b/tests/Refinery/Random/Transformation/ShuffleTransformationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @author  Lukas Scharmer <lscharmer@databay.de>
+ */
+namespace ILIAS\Tests\Refinery\Random\Transformation;
+
+use ILIAS\Refinery\Random\Transformation\ShuffleTransformation;
+use ILIAS\Refinery\Random\Seed\Seed;
+use ILIAS\Data\NotOKException;
+use ILIAS\Data\Result\Ok;
+use ILIAS\Data\Result\Error;
+use PHPUnit\Framework\TestCase;
+
+class ShuffleTransformationTest extends TestCase
+{
+    public function testTransformResultSuccess() : void
+    {
+        $value = ['nrrrrg'];
+        $seedMock = $this->getMockBuilder(Seed::class)->getMock();
+        $seedMock->expects(self::once())->method('seedRandomGenerator');
+
+        $result = (new ShuffleTransformation($seedMock))->transform($value);
+        $this->assertEquals($value, $result);
+    }
+
+    public function testTransformResultFailure() : void
+    {
+        $this->expectException(NotOKException::class);
+        $seedMock = $this->getMockBuilder(Seed::class)->getMock();
+        $seedMock->expects(self::never())->method('seedRandomGenerator');
+
+        $result = (new ShuffleTransformation($seedMock))->transform('im no array');
+    }
+}

--- a/tests/Setup/CLI/ConfigReaderTest.php
+++ b/tests/Setup/CLI/ConfigReaderTest.php
@@ -6,6 +6,7 @@ namespace ILIAS\Tests\Setup\CLI;
 
 use ILIAS\Setup;
 use PHPUnit\Framework\TestCase;
+use Seld\JsonLint\JsonParser;
 
 class ConfigReaderTest extends TestCase
 {
@@ -18,8 +19,7 @@ class ConfigReaderTest extends TestCase
             ]
         ];
         file_put_contents($filename, json_encode($expected));
-
-        $obj = new Setup\CLI\ConfigReader();
+        $obj = new Setup\CLI\ConfigReader(new JsonParser());
 
         $config = $obj->readConfigFile($filename);
 
@@ -36,7 +36,7 @@ class ConfigReaderTest extends TestCase
         ];
         file_put_contents($filename, json_encode($expected));
 
-        $obj = new Setup\CLI\ConfigReader("/tmp");
+        $obj = new Setup\CLI\ConfigReader(new JsonParser(), "/tmp");
 
         $config = $obj->readConfigFile(basename($filename));
 
@@ -53,7 +53,7 @@ class ConfigReaderTest extends TestCase
         ];
         file_put_contents($filename, json_encode($expected));
 
-        $obj = new Setup\CLI\ConfigReader("/foo");
+        $obj = new Setup\CLI\ConfigReader(new JsonParser(), "/foo");
 
         $config = $obj->readConfigFile($filename);
 
@@ -62,7 +62,7 @@ class ConfigReaderTest extends TestCase
 
     public function testApplyOverwrites() : void
     {
-        $cr = new class() extends Setup\CLI\ConfigReader {
+        $cr = new class(new JsonParser()) extends Setup\CLI\ConfigReader {
             public function _applyOverwrites($j, $o)
             {
                 return $this->applyOverwrites($j, $o);
@@ -98,7 +98,7 @@ class ConfigReaderTest extends TestCase
 
     public function testApplyOverwritesToUnsetField() : void
     {
-        $cr = new class() extends Setup\CLI\ConfigReader {
+        $cr = new class(new JsonParser()) extends Setup\CLI\ConfigReader {
             public function _applyOverwrites($j, $o)
             {
                 return $this->applyOverwrites($j, $o);


### PR DESCRIPTION
The new implementation uses the shuffle(...) function instead of the ilArrayElementShuffler::mtShuffle(...) method because since PHP 7.1 shuffle() already uses the Mersenne Twister algorithm. (see https://www.php.net/manual/en/function.shuffle.php)

The existence check for mt_srand and mt_rand is also removed, because it is replaced by srand in PHP 7.1 (see https://www.php.net/manual/en/function.mt-srand.php)