### PR TITLE
PHP 8: Code Review `Services/Skill`

### DIFF
--- a/Modules/Test/classes/class.ilTestPersonalSkillsGUI.php
+++ b/Modules/Test/classes/class.ilTestPersonalSkillsGUI.php
@@ -53,7 +53,7 @@ class ilTestPersonalSkillsGUI
 
         $gui->setProfileId($this->getSelectedSkillProfile());
 
-        $html = $gui->getGapAnalysisHTML($this->getUsrId(), $this->getAvailableSkills());
+        $html = $gui->getGapAnalysisHTML((int) $this->getUsrId(), $this->getAvailableSkills());
 
         return $html;
     }

--- a/Services/Skill/GlobalScreen/classes/class.ilSkillGSToolProvider.php
+++ b/Services/Skill/GlobalScreen/classes/class.ilSkillGSToolProvider.php
@@ -20,6 +20,7 @@
 use ILIAS\GlobalScreen\Scope\Tool\Provider\AbstractDynamicToolProvider;
 use ILIAS\GlobalScreen\ScreenContext\Stack\CalledContexts;
 use ILIAS\GlobalScreen\ScreenContext\Stack\ContextCollection;
+use ILIAS\UI\Component\Legacy\Legacy;
 
 /**
  * Workspace GS tool provider
@@ -57,21 +58,14 @@ class ilSkillGSToolProvider extends AbstractDynamicToolProvider
 
         $icon = $this->dic->ui()->factory()->symbol()->icon()->custom(\ilUtil::getImagePath("outlined/icon_skmg.svg"), $title);
 
-
         $additional_data = $called_contexts->current()->getAdditionalData();
         if ($additional_data->is(self::SHOW_SKILL_TREE, true)) {
             $tree_id = $additional_data->get(self::SKILL_TREE_ID);
-            $iff = function ($id) {
-                return $this->identification_provider->contextAwareIdentifier($id);
-            };
-            $l = function (string $content) {
-                return $this->dic->ui()->factory()->legacy($content);
-            };
-            $tools[] = $this->factory->tool($iff("tree"))
+            $tools[] = $this->factory->tool($this->identification_provider->contextAwareIdentifier("tree"))
                 ->withTitle($title)
                 ->withSymbol($icon)
-                ->withContentWrapper(function () use ($l, $tree_id) {
-                    return $l($this->getSkillTree($tree_id));
+                ->withContentWrapper(function () use ($tree_id) : Legacy {
+                    return $this->dic->ui()->factory()->legacy($this->getSkillTree($tree_id));
                 });
         }
 
@@ -80,17 +74,11 @@ class ilSkillGSToolProvider extends AbstractDynamicToolProvider
 
         if ($additional_data->is(self::SHOW_TEMPLATE_TREE, true)) {
             $tree_id = $additional_data->get(self::SKILL_TREE_ID);
-            $iff = function ($id) {
-                return $this->identification_provider->contextAwareIdentifier($id);
-            };
-            $l = function (string $content) {
-                return $this->dic->ui()->factory()->legacy($content);
-            };
-            $tools[] = $this->factory->tool($iff("tree"))
+            $tools[] = $this->factory->tool($this->identification_provider->contextAwareIdentifier("tree"))
                 ->withTitle("Templates")
                 ->withSymbol($icon)
-                ->withContentWrapper(function () use ($l, $tree_id) {
-                    return $l($this->getTemplateTree($tree_id));
+                ->withContentWrapper(function () use ($tree_id) : Legacy {
+                    return $this->dic->ui()->factory()->legacy($this->getTemplateTree($tree_id));
                 });
         }
         return $tools;

--- a/Services/Skill/Profile/class.ilSkillProfileCompletionManager.php
+++ b/Services/Skill/Profile/class.ilSkillProfileCompletionManager.php
@@ -43,6 +43,10 @@ class ilSkillProfileCompletionManager
         return $this->user_id;
     }
 
+    /**
+     * @param array{base_skill_id: int, tref_id: int, level_id: int} $a_skills
+     * @return array<int, array<int, int>>
+     */
     public function getActualMaxLevels(
         array $a_skills = null,
         string $a_gap_mode = "",
@@ -73,6 +77,7 @@ class ilSkillProfileCompletionManager
         int $a_gap_mode_obj_id = 0
     ) : array {
         // todo for coming feature
+        return [];
     }
 
     /**
@@ -121,6 +126,7 @@ class ilSkillProfileCompletionManager
 
     /**
      * Get all profiles of user which are fulfilled or non-fulfilled
+     * @return array<int, bool>
      */
     public function getAllProfileCompletionsForUser() : array
     {

--- a/Services/Skill/Profile/class.ilSkillProfileCompletionRepository.php
+++ b/Services/Skill/Profile/class.ilSkillProfileCompletionRepository.php
@@ -172,6 +172,7 @@ class ilSkillProfileCompletionRepository
 
     /**
      * Get all profile completion entries for a user
+     * @return array{profile_id: int, user_id: int, date: string, fulfilled: int}[]
      */
     public static function getFulfilledEntriesForUser(int $a_user_id) : array
     {
@@ -187,10 +188,10 @@ class ilSkillProfileCompletionRepository
         $entries = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
             $entries[] = array(
-                "profile_id" => $rec["profile_id"],
-                "user_id" => $rec["user_id"],
+                "profile_id" => (int) $rec["profile_id"],
+                "user_id" => (int) $rec["user_id"],
                 "date" => $rec["date"],
-                "fulfilled" => $rec["fulfilled"]
+                "fulfilled" => (int) $rec["fulfilled"]
             );
         }
 

--- a/Services/Skill/Profile/class.ilSkillProfileGUI.php
+++ b/Services/Skill/Profile/class.ilSkillProfileGUI.php
@@ -51,14 +51,34 @@ class ilSkillProfileGUI
     protected SkillAdminGUIRequest $admin_gui_request;
     protected int $requested_ref_id = 0;
     protected int $requested_sprof_id = 0;
+
+    /**
+     * @var int[]
+     */
     protected array $requested_profile_ids = [];
     protected bool $requested_local_context = false;
     protected string $requested_cskill_id = "";
     protected int $requested_level_id = 0;
+
+    /**
+     * @var string[]
+     */
     protected array $requested_level_ass_ids = [];
+
+    /**
+     * @var int[]
+     */
     protected array $requested_level_order = [];
     protected string $requested_user_login = "";
+
+    /**
+     * @var int[]
+     */
     protected array $requested_users = [];
+
+    /**
+     * @var int[]
+     */
     protected array $requested_user_ids = [];
     protected bool $local_context = false;
 
@@ -901,11 +921,11 @@ class ilSkillProfileGUI
                 $type = ilObject::_lookupType($i);
                 switch ($type) {
                     case 'usr':
-                        $this->profile->removeUserFromProfile((int) $i);
+                        $this->profile->removeUserFromProfile($i);
                         break;
 
                     case 'role':
-                        $this->profile->removeRoleFromProfile((int) $i);
+                        $this->profile->removeRoleFromProfile($i);
                         break;
 
                     default:

--- a/Services/Skill/Resources/class.ilSkillResources.php
+++ b/Services/Skill/Resources/class.ilSkillResources.php
@@ -45,6 +45,9 @@ class ilSkillResources implements ilSkillUsageInfo
     // rep_ref_id (int): the ref id of the repository resource
     // trigger: 1, if the resource triggers the skill level (0 otherwise)
     // imparting: 1, if the resource imparts knowledge of the skill level (0 otherwise)
+    /**
+     * @var array<int, array<int, array{level_id: int, rep_ref_id: int, trigger: int, imparting: int}>>
+     */
     protected array $resources = [];
 
     public function __construct(int $a_skill_id = 0, int $a_tref_id = 0)
@@ -93,12 +96,12 @@ class ilSkillResources implements ilSkillUsageInfo
         );
         while ($rec = $ilDB->fetchAssoc($set)) {
             if ($tree->isInTree($rec["rep_ref_id"])) {
-                $this->resources[$rec["level_id"]][$rec["rep_ref_id"]] = array(
-                    "level_id" => $rec["level_id"],
-                    "rep_ref_id" => $rec["rep_ref_id"],
-                    "trigger" => $rec["ltrigger"],
-                    "imparting" => $rec["imparting"]
-                    );
+                $this->resources[(int) $rec["level_id"]][(int) $rec["rep_ref_id"]] = array(
+                    "level_id" => (int) $rec["level_id"],
+                    "rep_ref_id" => (int) $rec["rep_ref_id"],
+                    "trigger" => (int) $rec["ltrigger"],
+                    "imparting" => (int) $rec["imparting"]
+                );
             }
         }
     }
@@ -119,8 +122,8 @@ class ilSkillResources implements ilSkillUsageInfo
                         "(base_skill_id, tref_id, level_id, rep_ref_id, imparting, ltrigger) VALUES (" .
                         $ilDB->quote($this->getBaseSkillId(), "integer") . "," .
                         $ilDB->quote($this->getTemplateRefId(), "integer") . "," .
-                        $ilDB->quote((int) $level_id, "integer") . "," .
-                        $ilDB->quote((int) $ref_id, "integer") . "," .
+                        $ilDB->quote($level_id, "integer") . "," .
+                        $ilDB->quote($ref_id, "integer") . "," .
                         $ilDB->quote((int) $r["imparting"], "integer") . "," .
                         $ilDB->quote((int) $r["trigger"], "integer") .
                         ")");
@@ -129,11 +132,17 @@ class ilSkillResources implements ilSkillUsageInfo
         }
     }
 
+    /**
+     * @return array<int, array<int, array{level_id: int, rep_ref_id: int, trigger: int, imparting: int}>>
+     */
     public function getResources() : array
     {
         return $this->resources;
     }
 
+    /**
+     * @return array<int, array{level_id: int, rep_ref_id: int, trigger: int, imparting: int}>
+     */
     public function getResourcesOfLevel(int $a_level_id) : array
     {
         $ret = (isset($this->resources[$a_level_id]) && is_array($this->resources[$a_level_id]))
@@ -167,11 +176,15 @@ class ilSkillResources implements ilSkillUsageInfo
         $this->resources[$a_level_id][$a_rep_ref_id]["imparting"] = $a_imparting;
     }
 
-    public static function getUsageInfo(array $a_cskill_ids, array &$a_usages)
+    /**
+     * @param array{skill_id: int, tref_id: int}[] $a_cskill_ids array of common skill ids
+     *
+     * @return array<string, array<string, array{key: string}[]>>
+     */
+    public static function getUsageInfo(array $a_cskill_ids) : array
     {
-        ilSkillUsage::getUsageInfoGeneric(
+        return ilSkillUsage::getUsageInfoGeneric(
             $a_cskill_ids,
-            $a_usages,
             ilSkillUsage::RESOURCE,
             "skl_skill_resource",
             "rep_ref_id",
@@ -179,6 +192,9 @@ class ilSkillResources implements ilSkillUsageInfo
         );
     }
 
+    /**
+     * @return array{base_skill_id: int, tref_id: int, level_id: int}[]
+     */
     public static function getTriggerLevelsForRefId(int $a_ref_id) : array
     {
         global $DIC;
@@ -192,9 +208,9 @@ class ilSkillResources implements ilSkillUsageInfo
         $skill_levels = [];
         while ($rec = $db->fetchAssoc($set)) {
             $skill_levels[] = array(
-                "base_skill_id" => $rec["base_skill_id"],
-                "tref_id" => $rec["tref_id"],
-                "level_id" => $rec["level_id"]
+                "base_skill_id" => (int) $rec["base_skill_id"],
+                "tref_id" => (int) $rec["tref_id"],
+                "level_id" => (int) $rec["level_id"]
             );
         }
         return $skill_levels;

--- a/Services/Skill/Resources/class.ilSkillResourcesManager.php
+++ b/Services/Skill/Resources/class.ilSkillResourcesManager.php
@@ -55,13 +55,16 @@ class ilSkillResourcesManager
         return $too_low;
     }
 
+    /**
+     * @return array{level_id: int, rep_ref_id: int, trigger: int, imparting: int}[]
+     */
     public function getSuggestedResources() : array
     {
         $resources = $this->res->getResources();
         $imp_resources = [];
         foreach ($resources as $level) {
             foreach ($level as $r) {
-                if ($r["imparting"] == true &&
+                if ($r["imparting"] &&
                     $this->current_target_level == $r["level_id"]) {
                     $imp_resources[] = $r;
                 }

--- a/Services/Skill/Service/classes/class.SkillAdminGUIRequest.php
+++ b/Services/Skill/Service/classes/class.SkillAdminGUIRequest.php
@@ -93,6 +93,9 @@ class SkillAdminGUIRequest extends SkillGUIRequest
         return $this->bool("local_context");
     }
 
+    /**
+     * @return int[]
+     */
     public function getOrder() : array
     {
         return $this->intArray("order");
@@ -103,41 +106,65 @@ class SkillAdminGUIRequest extends SkillGUIRequest
         return $this->int("level_id");
     }
 
+    /**
+     * @return int[]
+     */
     public function getLevelIds() : array
     {
         return $this->getIds();
     }
 
+    /**
+     * @return string[]
+     */
     public function getAssignedLevelIds() : array
     {
         return $this->strArray("ass_id");
     }
 
+    /**
+     * @return int[]
+     */
     public function getResourceIds() : array
     {
         return $this->getIds();
     }
 
+    /**
+     * @return bool[]
+     */
     public function getSuggested() : array
     {
         return $this->boolArray("suggested");
     }
 
+    /**
+     * @return bool[]
+     */
     public function getTrigger() : array
     {
         return $this->boolArray("trigger");
     }
 
+    /**
+     * @return string[]
+     */
     public function getTitles() : array
     {
         return $this->strArray("title");
     }
 
+    /**
+     * @return int[]
+     */
     public function getNodeIds() : array
     {
         return $this->getIds();
     }
 
+    /**
+     * @return int[]
+     */
     public function getProfileIds() : array
     {
         return $this->getIds();
@@ -148,16 +175,25 @@ class SkillAdminGUIRequest extends SkillGUIRequest
         return $this->str("user_login");
     }
 
+    /**
+     * @return int[]
+     */
     public function getUsers() : array
     {
         return $this->intArray("user");
     }
 
+    /**
+     * @return int[]
+     */
     public function getUserIds() : array
     {
         return $this->getIds();
     }
 
+    /**
+     * @return string[]
+     */
     public function getSelectedIds(string $post_var) : array
     {
         return $this->strArray($post_var);

--- a/Services/Skill/Service/classes/class.SkillGUIRequest.php
+++ b/Services/Skill/Service/classes/class.SkillGUIRequest.php
@@ -54,7 +54,7 @@ class SkillGUIRequest
     /**
      * get integer parameter kindly
      */
-    protected function int($key) : int
+    protected function int(string $key) : int
     {
         $t = $this->refinery->kindlyTo()->int();
         return (int) ($this->get($key, $t) ?? 0);
@@ -62,26 +62,17 @@ class SkillGUIRequest
 
     /**
      * get integer array kindly
+     * @return int[]|array<int|string, int>
      */
-    protected function intArray($key) : array
+    protected function intArray(string $key) : array
     {
         if (!$this->isArray($key)) {
             return [];
         }
         $t = $this->refinery->custom()->transformation(
-            function ($arr) {
+            static function (array $arr) : array {
                 // keep keys(!), transform all values to int
-                return array_column(
-                    array_map(
-                        function ($k, $v) {
-                            return [$k, (int) $v];
-                        },
-                        array_keys($arr),
-                        $arr
-                    ),
-                    1,
-                    0
-                );
+                return array_map('intval', $arr);
             }
         );
         return (array) ($this->get($key, $t) ?? []);
@@ -90,7 +81,7 @@ class SkillGUIRequest
     /**
      * get string parameter kindly
      */
-    protected function str($key) : string
+    protected function str(string $key) : string
     {
         $t = $this->refinery->kindlyTo()->string();
         return \ilUtil::stripSlashes((string) ($this->get($key, $t) ?? ""));
@@ -98,25 +89,21 @@ class SkillGUIRequest
 
     /**
      * get string array kindly
+     * @return string[]|array<int|string, string>
      */
-    protected function strArray($key) : array
+    protected function strArray(string $key) : array
     {
         if (!$this->isArray($key)) {
             return [];
         }
         $t = $this->refinery->custom()->transformation(
-            function ($arr) {
+            static function (array $arr) : array {
                 // keep keys(!), transform all values to string
-                return array_column(
-                    array_map(
-                        function ($k, $v) {
-                            return [$k, \ilUtil::stripSlashes((string) $v)];
-                        },
-                        array_keys($arr),
-                        $arr
-                    ),
-                    1,
-                    0
+                return array_map(
+                    static function ($v) : string {
+                        return \ilUtil::stripSlashes((string) $v);
+                    },
+                    $arr
                 );
             }
         );
@@ -126,7 +113,7 @@ class SkillGUIRequest
     /**
      * get bool parameter kindly
      */
-    protected function bool($key) : bool
+    protected function bool(string $key) : bool
     {
         $t = $this->refinery->kindlyTo()->bool();
         return (bool) ($this->get($key, $t) ?? false);
@@ -134,26 +121,17 @@ class SkillGUIRequest
 
     /**
      * get bool array kindly
+     * @return bool[]|array<int|string, bool>
      */
-    protected function boolArray($key) : array
+    protected function boolArray(string $key) : array
     {
         if (!$this->isArray($key)) {
             return [];
         }
         $t = $this->refinery->custom()->transformation(
-            function ($arr) {
+            static function (array $arr) : array {
                 // keep keys(!), transform all values to bool
-                return array_column(
-                    array_map(
-                        function ($k, $v) {
-                            return [$k, (bool) $v];
-                        },
-                        array_keys($arr),
-                        $arr
-                    ),
-                    1,
-                    0
-                );
+                return array_map('boolval', $arr);
             }
         );
         return (array) ($this->get($key, $t) ?? []);
@@ -165,9 +143,7 @@ class SkillGUIRequest
     protected function isArray(string $key) : bool
     {
         if ($this->passed_query_params === null && $this->passed_post_data === null) {
-            $no_transform = $this->refinery->custom()->transformation(function ($v) {
-                return $v;
-            });
+            $no_transform = $this->refinery->identity();
             $w = $this->http->wrapper();
             if ($w->post()->has($key)) {
                 return is_array($w->post()->retrieve($key, $no_transform));

--- a/Services/Skill/Service/classes/class.SkillPersonalGUIRequest.php
+++ b/Services/Skill/Service/classes/class.SkillPersonalGUIRequest.php
@@ -53,6 +53,9 @@ class SkillPersonalGUIRequest extends SkillGUIRequest
         return $this->int("skill_id");
     }
 
+    /**
+     * @return int[]
+     */
     public function getSkillIds() : array
     {
         return $this->getIds();
@@ -83,6 +86,9 @@ class SkillPersonalGUIRequest extends SkillGUIRequest
         return $this->int("wsp_id");
     }
 
+    /**
+     * @return int[]
+     */
     public function getWorkspaceIds() : array
     {
         return $this->intArray("wsp_id");

--- a/Services/Skill/Service/classes/class.SkillTreeService.php
+++ b/Services/Skill/Service/classes/class.SkillTreeService.php
@@ -82,6 +82,9 @@ class SkillTreeService
         return $vtree;
     }
 
+    /**
+     * @return array{skill_id: int, child: int, tref_id: int, parent: int}[]
+     */
     public function getSkillTreePath(int $base_skill_id, int $tref_id = 0) : array
     {
         $tree = $this->tree_repo->getTreeForNodeId($base_skill_id);
@@ -97,6 +100,9 @@ class SkillTreeService
         return $obj_tree;
     }
 
+    /**
+     * @return \ilObjSkillTree[]
+     */
     public function getObjSkillTrees() : array
     {
         $obj_trees = iterator_to_array($this->tree_manager->getTrees());

--- a/Services/Skill/Service/classes/class.SkillUIService.php
+++ b/Services/Skill/Service/classes/class.SkillUIService.php
@@ -29,7 +29,7 @@ class SkillUIService
     {
     }
 
-    public function getGapUI() //int $user_id, int $profile_id,...
+    public function getGapUI() : void //int $user_id, int $profile_id,...
     {
     }
 }

--- a/Services/Skill/Tree/class.SkillTreeTableGUI.php
+++ b/Services/Skill/Tree/class.SkillTreeTableGUI.php
@@ -76,18 +76,18 @@ class SkillTreeTableGUI extends \ilTable2GUI
     }
 
     /**
-     * @return array[]
+     * @return array({title: string, tree: \ilObjSkillTree}|array{})[]
      */
     protected function getItems() : array
     {
         return array_filter(array_map(
-            function ($i) {
-                $tree_access_manager = $this->internal_manager->getTreeAccessManager($i->getRefId());
+            function (\ilObjSkillTree $skillTree) : array {
+                $tree_access_manager = $this->internal_manager->getTreeAccessManager($skillTree->getRefId());
                 if ($tree_access_manager->hasVisibleTreePermission()) {
                     return [
-                    "title" => $i->getTitle(),
-                    "tree" => $i
-                ];
+                        "title" => $skillTree->getTitle(),
+                        "tree" => $skillTree
+                    ];
                 }
                 return [];
             },
@@ -95,6 +95,9 @@ class SkillTreeTableGUI extends \ilTable2GUI
         ));
     }
 
+    /**
+     * @param array{tree: \ilObjSkillTree}
+     */
     protected function fillRow(array $a_set) : void
     {
         $tpl = $this->tpl;

--- a/Services/Skill/Tree/class.ilGlobalSkillTree.php
+++ b/Services/Skill/Tree/class.ilGlobalSkillTree.php
@@ -40,6 +40,9 @@ class ilGlobalSkillTree extends ilSkillTree
         $this->tree_repo = $DIC->skills()->internal()->repo()->getTreeRepo();
     }
 
+    /**
+     * @return array{child: int, parent: int}
+     */
     public function getNodeData(int $a_node_id, ?int $a_tree_pk = null) : array
     {
         if ($a_node_id == 0) {
@@ -48,6 +51,9 @@ class ilGlobalSkillTree extends ilSkillTree
         return parent::getNodeData($a_node_id, $a_tree_pk);
     }
 
+    /**
+     * @return array{parent: int, depth: int, obj_id: int, child: int}
+     */
     public function getRootNode() : array
     {
         $root_node = [];
@@ -65,6 +71,9 @@ class ilGlobalSkillTree extends ilSkillTree
         return 0;
     }
 
+    /**
+     * @return array{child: int, parent: int}[]
+     */
     public function getChilds(int $a_node_id, string $a_order = "", string $a_direction = "ASC") : array
     {
         if ($a_node_id == 0) {

--- a/Services/Skill/Tree/class.ilGlobalVirtualSkillTree.php
+++ b/Services/Skill/Tree/class.ilGlobalVirtualSkillTree.php
@@ -26,12 +26,6 @@ use ILIAS\Skill\Tree\SkillTreeFactory;
  */
 class ilGlobalVirtualSkillTree extends ilVirtualSkillTree
 {
-    protected ilLanguage $lng;
-    protected static ?array $order_node_data = null;
-    protected bool $include_drafts = false;
-    protected array $drafts = [];
-    protected bool $include_outdated = false;
-    protected array $outdated = [];
     protected bool $root_node_processed = false;
     protected SkillTreeManager $skill_tree_manager;
     protected SkillTreeFactory $skill_tree_factory;
@@ -47,6 +41,9 @@ class ilGlobalVirtualSkillTree extends ilVirtualSkillTree
         $this->tree_repo = $DIC->skills()->internal()->repo()->getTreeRepo();
     }
 
+    /**
+     * @return array{id: int, parent: int, depth: int, obj_id: int}
+     */
     public function getRootNode() : array
     {
         $root_id = 0;
@@ -60,6 +57,9 @@ class ilGlobalVirtualSkillTree extends ilVirtualSkillTree
         return $root_node;
     }
 
+    /**
+     * @return array{id: int, child: int, parent: int}[]
+     */
     public function getChildsOfNode(string $a_parent_id) : array
     {
         if ($a_parent_id === "0") {
@@ -79,13 +79,14 @@ class ilGlobalVirtualSkillTree extends ilVirtualSkillTree
         }
     }
 
+    /**
+     * @return {cskill_id: string, id: string, skill_id: string, tref_id: string, parent: string, type: string}[]
+     */
     public function getSubTreeForTreeId(string $a_tree_id) : array
     {
-        $result = [];
-        $node = $this->getNode($a_tree_id);
-        $result[] = $node;
-        $this->__getSubTreeRec($a_tree_id, $result, false);
-
-        return $result;
+        return array_merge(
+            [$this->getNode($a_tree_id)],
+            $this->__getSubTreeRec($a_tree_id, false)
+        );
     }
 }

--- a/Services/Skill/Tree/class.ilObjSkillTreeGUI.php
+++ b/Services/Skill/Tree/class.ilObjSkillTreeGUI.php
@@ -53,7 +53,15 @@ class ilObjSkillTreeGUI extends ilObjectGUI
     protected int $requested_templates_tree = 0;
     protected string $requested_skexpand = "";
     protected int $requested_tmpmode = 0;
+
+    /**
+     * @var string[]
+     */
     protected array $requested_titles = [];
+
+    /**
+     * @var int[]
+     */
     protected array $requested_node_ids = [];
 
     /**
@@ -769,7 +777,7 @@ class ilObjSkillTreeGUI extends ilObjectGUI
     // Tree
     //
 
-    public function showTree($a_templates, $a_gui = "", $a_gui_cmd = "") : void
+    public function showTree(bool $a_templates, $a_gui = "", $a_gui_cmd = "") : void
     {
         $ilUser = $this->user;
         $tpl = $this->tpl;

--- a/Services/Skill/Tree/class.ilSkillTemplateTreeExplorerGUI.php
+++ b/Services/Skill/Tree/class.ilSkillTemplateTreeExplorerGUI.php
@@ -28,7 +28,13 @@ class ilSkillTemplateTreeExplorerGUI extends ilTreeExplorerGUI
 {
     protected SkillAdminGUIRequest $admin_gui_request;
     protected int $requested_skill_node_id = 0;
+    /**
+     * @var array<int, int>
+     */
     protected array $parent = [];
+    /**
+     * @var array<int, bool>
+     */
     protected array $draft = [];
 
     /**

--- a/Services/Skill/Tree/class.ilSkillTree.php
+++ b/Services/Skill/Tree/class.ilSkillTree.php
@@ -31,6 +31,9 @@ class ilSkillTree extends ilTree
         $this->setTableNames('skl_tree', 'skl_tree_node');
     }
 
+    /**
+     * @return array{skill_id: int, child: int, tref_id: int, parent: int}[]
+     */
     public function getSkillTreePath(int $a_base_skill_id, int $a_tref_id = 0) : array
     {
         if ($a_tref_id > 0) {
@@ -112,11 +115,6 @@ class ilSkillTree extends ilTree
             );
         }
 
-        $max = 0;
-        foreach ($childs as $k => $c) {
-            $max = max(array($c["order_nr"], $max));
-        }
-
-        return $max;
+        return max(0, ...array_column($childs, 'order_nr'));
     }
 }

--- a/Services/Skill/Tree/class.ilSkillTreeNode.php
+++ b/Services/Skill/Tree/class.ilSkillTreeNode.php
@@ -35,6 +35,19 @@ class ilSkillTreeNode
     protected string $import_id = "";
     protected string $creation_date = "";
     protected int $status = 0;
+
+    /**
+     * @var array{
+     *   type: string,
+     *   title: string,
+     *   description: string,
+     *   order_nr: int,
+     *   self_eval: bool,
+     *   status: int,
+     *   import_id: string,
+     *   creation_date: string
+     * }
+     */
     protected array $data_record = [];
 
     public const STATUS_PUBLISH = 0;
@@ -181,11 +194,14 @@ class ilSkillTreeNode
             $obj_set = $ilDB->query($query);
             $this->data_record = $ilDB->fetchAssoc($obj_set);
         }
+        $this->data_record["order_nr"] = (int) $this->data_record["order_nr"];
+        $this->data_record["self_eval"] = (bool) $this->data_record["self_eval"];
+        $this->data_record["status"] = (int) $this->data_record["status"];
         $this->setType($this->data_record["type"]);
         $this->setTitle($this->data_record["title"]);
         $this->setDescription($this->data_record["description"] ?? "");
         $this->setOrderNr($this->data_record["order_nr"]);
-        $this->setSelfEvaluation((bool) $this->data_record["self_eval"]);
+        $this->setSelfEvaluation($this->data_record["self_eval"]);
         $this->setStatus($this->data_record["status"]);
         $this->setImportId($this->data_record["import_id"] ?? "");
         $this->setCreationDate($this->data_record["creation_date"] ?? "");
@@ -199,7 +215,7 @@ class ilSkillTreeNode
         $this->data_record = $a_record;
     }
 
-    protected static function _lookup(int $a_obj_id, string $a_field)
+    protected static function _lookup(int $a_obj_id, string $a_field) : ?string
     {
         global $DIC;
 
@@ -210,7 +226,7 @@ class ilSkillTreeNode
         $obj_set = $ilDB->query($query);
         $obj_rec = $ilDB->fetchAssoc($obj_set);
 
-        return $obj_rec[$a_field];
+        return isset($obj_rec[$a_field]) ? (string) $obj_rec[$a_field] : null;
     }
 
     public static function _lookupTitle(int $a_obj_id, int $a_tref_id = 0) : string
@@ -355,10 +371,7 @@ class ilSkillTreeNode
         $ilDB->manipulate($query);
     }
 
-    /**
-    * Delete Node
-    */
-    public function delete()
+    public function delete() : void
     {
         $ilDB = $this->db;
         
@@ -373,11 +386,9 @@ class ilSkillTreeNode
     public static function uniqueTypesCheck(array $a_items) : bool
     {
         $types = [];
-        if (is_array($a_items)) {
-            foreach ($a_items as $item) {
-                $type = ilSkillTreeNode::_lookupType($item);
-                $types[$type] = $type;
-            }
+        foreach ($a_items as $item) {
+            $type = ilSkillTreeNode::_lookupType($item);
+            $types[$type] = $type;
         }
 
         if (count($types) > 1) {
@@ -386,6 +397,9 @@ class ilSkillTreeNode
         return true;
     }
 
+    /**
+     * @return array<int, string>
+     */
     public static function getAllSelfEvaluationNodes() : array
     {
         global $DIC;
@@ -398,11 +412,15 @@ class ilSkillTreeNode
         );
         $nodes = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
+            $rec["obj_id"] = (int) $rec["obj_id"];
             $nodes[$rec["obj_id"]] = $rec["title"];
         }
         return $nodes;
     }
 
+    /**
+     * @return array{obj_id: int, order_nr: int, status: int, self_eval: bool, title: string, type: string, create_date: string, description: string}[]
+     */
     public static function getSelectableSkills() : array
     {
         global $DIC;
@@ -416,6 +434,10 @@ class ilSkillTreeNode
         
         $sel_skills = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
+            $rec['obj_id'] = (int) $rec['obj_id'];
+            $rec['order_nr'] = (int) $rec['order_nr'];
+            $rec['status'] = (int) $rec['status'];
+            $rec['self_eval'] = (bool) $rec['self_eval'];
             $sel_skills[] = $rec;
         }
         

--- a/Services/Skill/Tree/class.ilSkillTreeNodeGUI.php
+++ b/Services/Skill/Tree/class.ilSkillTreeNodeGUI.php
@@ -51,7 +51,16 @@ class ilSkillTreeNodeGUI
     protected int $requested_node_id = 0;
     protected string $requested_backcmd = "";
     protected int $requested_tmpmode = 0;
+    protected int $base_skill_id = 0;
+
+    /**
+     * @var int[]
+     */
     protected array $requested_node_ids = [];
+
+    /**
+     * @var int[]
+     */
     protected array $requested_node_order = [];
 
     public function __construct(Tree\SkillTreeNodeManager $node_manager, int $a_node_id = 0)

--- a/Services/Skill/Tree/class.ilVirtualSkillTreeExplorerGUI.php
+++ b/Services/Skill/Tree/class.ilVirtualSkillTreeExplorerGUI.php
@@ -78,6 +78,9 @@ class ilVirtualSkillTreeExplorerGUI extends ilExplorerBaseGUI
         return $this->show_outdated_nodes;
     }
 
+    /**
+     * @return array{id: string, cskill_id: string}
+     */
     public function getRootNode() : array
     {
         return $this->vtree->getRootNode();
@@ -103,7 +106,7 @@ class ilVirtualSkillTreeExplorerGUI extends ilExplorerBaseGUI
     /**
      * @inheritdoc
      */
-    public function getNodeIdForDomNodeId($a_dom_node_id) : string
+    public function getNodeIdForDomNodeId(string $a_dom_node_id) : string
     {
         $id = parent::getNodeIdForDomNodeId($a_dom_node_id);
         return str_replace("_", ":", $id);
@@ -111,7 +114,7 @@ class ilVirtualSkillTreeExplorerGUI extends ilExplorerBaseGUI
 
     /**
      * @param string $a_parent_node_id
-     * @return array
+     * @return array{cskill_id: string, id: string, skill_id: string, tref_id: string, parent: string}[]
      */
     public function getChildsOfNode($a_parent_node_id) : array
     {

--- a/Services/Skill/classes/Provider/SkillMainBarProvider.php
+++ b/Services/Skill/classes/Provider/SkillMainBarProvider.php
@@ -65,9 +65,9 @@ class SkillMainBarProvider extends AbstractStaticMainMenuProvider
                 ->withParent(StandardTopItemsProvider::getInstance()->getAchievementsIdentification())
                 ->withPosition(20)
                 ->withSymbol($icon)
-                ->withNonAvailableReason($this->dic->ui()->factory()->legacy("{$this->dic->language()->txt('component_not_active')}"))
+                ->withNonAvailableReason($this->dic->ui()->factory()->legacy($this->dic->language()->txt('component_not_active')))
                 ->withAvailableCallable(
-                    function () {
+                    static function () : bool {
                         $skmg_set = new ilSetting("skmg");
 
                         return (bool) ($skmg_set->get("enable_skmg"));

--- a/Services/Skill/classes/Setup/class.ilSkillDBUpdateSteps.php
+++ b/Services/Skill/classes/Setup/class.ilSkillDBUpdateSteps.php
@@ -26,7 +26,7 @@ class ilSkillDBUpdateSteps implements ilDatabaseUpdateSteps
         $this->db = $db;
     }
 
-    public function step_1()
+    public function step_1() : void
     {
         if ($this->db->sequenceExists('skl_self_eval')) {
             $this->db->dropSequence('skl_self_eval');
@@ -41,7 +41,7 @@ class ilSkillDBUpdateSteps implements ilDatabaseUpdateSteps
         }
     }
 
-    public function step_2()
+    public function step_2() : void
     {
         if (!$this->db->tableColumnExists('skl_user_skill_level', 'trigger_user_id')) {
             $this->db->addTableColumn(
@@ -57,7 +57,7 @@ class ilSkillDBUpdateSteps implements ilDatabaseUpdateSteps
         }
     }
 
-    public function step_3()
+    public function step_3() : void
     {
         if (!$this->db->tableColumnExists('skl_user_has_level', 'trigger_user_id')) {
             $this->db->addTableColumn(
@@ -73,7 +73,7 @@ class ilSkillDBUpdateSteps implements ilDatabaseUpdateSteps
         }
     }
 
-    public function step_4()
+    public function step_4() : void
     {
         include_once 'Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php';
 
@@ -140,7 +140,7 @@ class ilSkillDBUpdateSteps implements ilDatabaseUpdateSteps
         }
     }
 
-    public function step_5()
+    public function step_5() : void
     {
         include_once 'Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php';
         $skill_tree_type_id = ilDBUpdateNewObjectType::getObjectTypeId('skee');
@@ -157,7 +157,7 @@ class ilSkillDBUpdateSteps implements ilDatabaseUpdateSteps
         ilDBUpdateNewObjectType::addRBACOperation($skill_tree_type_id, $ops_id);
     }
 
-    public function step_6()
+    public function step_6() : void
     {
         // get skill managemenet object id
         $set = $this->db->queryF(
@@ -205,7 +205,7 @@ class ilSkillDBUpdateSteps implements ilDatabaseUpdateSteps
         $tree->insertNode($ref_id, (int) $skmg_ref_id);
     }
 
-    public function step_7()
+    public function step_7() : void
     {
         $set = $this->db->queryF(
             "SELECT * FROM object_data " .
@@ -226,7 +226,7 @@ class ilSkillDBUpdateSteps implements ilDatabaseUpdateSteps
         );
     }
 
-    public function step_8()
+    public function step_8() : void
     {
         if (!$this->db->tableColumnExists("skl_profile", "skill_tree_id")) {
             $this->db->addTableColumn("skl_profile", "skill_tree_id", array(
@@ -238,7 +238,7 @@ class ilSkillDBUpdateSteps implements ilDatabaseUpdateSteps
         }
     }
 
-    public function step_9()
+    public function step_9() : void
     {
         $set = $this->db->queryF(
             "SELECT * FROM object_data " .
@@ -259,7 +259,7 @@ class ilSkillDBUpdateSteps implements ilDatabaseUpdateSteps
         );
     }
 
-    public function step_10()
+    public function step_10() : void
     {
         if (!$this->db->tableColumnExists("skl_profile", "image_id")) {
             $this->db->addTableColumn("skl_profile", "image_id", array(
@@ -270,7 +270,7 @@ class ilSkillDBUpdateSteps implements ilDatabaseUpdateSteps
         }
     }
 
-    public function step_11()
+    public function step_11() : void
     {
         if (!$this->db->tableExists("skl_profile_completion")) {
             $fields = [

--- a/Services/Skill/classes/class.ilBasicSkill.php
+++ b/Services/Skill/classes/class.ilBasicSkill.php
@@ -543,11 +543,10 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
         return "Skill";
     }
 
-    public static function getUsageInfo(array $a_cskill_ids, array &$a_usages) // return type?
+    public static function getUsageInfo(array $a_cskill_ids) : array
     {
-        ilSkillUsage::getUsageInfoGeneric(
+        return ilSkillUsage::getUsageInfoGeneric(
             $a_cskill_ids,
-            $a_usages,
             ilSkillUsage::USER_ASSIGNED,
             "skl_user_skill_level",
             "user_id"

--- a/Services/Skill/classes/class.ilBasicSkillGUI.php
+++ b/Services/Skill/classes/class.ilBasicSkillGUI.php
@@ -42,13 +42,32 @@ class ilBasicSkillGUI extends ilSkillTreeNodeGUI
     protected ServerRequestInterface $request;
 
     protected int $tref_id = 0;
-    protected int $base_skill_id = 0;
     protected int $requested_level_id = 0;
     protected int $requested_root_id = 0;
+
+    /**
+     * @var int[]
+     */
     protected array $requested_level_order = [];
+
+    /**
+     * @var int[]
+     */
     protected array $requested_level_ids = [];
+
+    /**
+     * @var int[]
+     */
     protected array $requested_resource_ids = [];
+
+    /**
+     * @var array<int, bool>
+     */
     protected array $requested_suggested = [];
+
+    /**
+     * @var array<int, bool>
+     */
     protected array $requested_trigger = [];
 
     public function __construct(Tree\SkillTreeNodeManager $node_manager, int $a_node_id = 0)
@@ -449,7 +468,7 @@ class ilBasicSkillGUI extends ilSkillTreeNodeGUI
 
         if (!empty($this->requested_level_ids)) {
             foreach ($this->requested_level_ids as $id) {
-                $this->node_object->deleteLevel((int) $id);
+                $this->node_object->deleteLevel($id);
             }
             $this->node_object->fixLevelNumbering();
         }

--- a/Services/Skill/classes/class.ilBasicSkillLevelDBRepository.php
+++ b/Services/Skill/classes/class.ilBasicSkillLevelDBRepository.php
@@ -73,6 +73,9 @@ class ilBasicSkillLevelDBRepository implements ilBasicSkillLevelRepository
         return (int) $rec["mnr"] ?? 0;
     }
 
+    /**
+     * Returns multiple rows when $a_id is 0 else one or [].
+     */
     public function getLevelData(int $skill_id, int $a_id = 0) : array
     {
         $ilDB = $this->db;
@@ -98,7 +101,7 @@ class ilBasicSkillLevelDBRepository implements ilBasicSkillLevelRepository
         return $levels;
     }
 
-    protected function lookupLevelProperty(int $a_id, string $a_prop)
+    protected function lookupLevelProperty(int $a_id, string $a_prop) : ?string
     {
         $ilDB = $this->db;
 
@@ -107,7 +110,8 @@ class ilBasicSkillLevelDBRepository implements ilBasicSkillLevelRepository
             " id = " . $ilDB->quote($a_id, "integer")
         );
         $rec = $ilDB->fetchAssoc($set);
-        return $rec[$a_prop];
+
+        return isset($rec[$a_prop]) ? (string) $rec[$a_prop] : null;
     }
 
     public function lookupLevelTitle(int $a_id) : string
@@ -125,7 +129,7 @@ class ilBasicSkillLevelDBRepository implements ilBasicSkillLevelRepository
         return $this->lookupLevelProperty($a_id, "skill_id") ?? 0;
     }
 
-    protected function writeLevelProperty(int $a_id, string $a_prop, $a_value, string $a_type) : void
+    protected function writeLevelProperty(int $a_id, string $a_prop, ?string $a_value, string $a_type) : void
     {
         $ilDB = $this->db;
 
@@ -201,8 +205,8 @@ class ilBasicSkillLevelDBRepository implements ilBasicSkillLevelRepository
         );
         $skill = null;
         if ($rec = $ilDB->fetchAssoc($set)) {
-            if ($this->tree_repo->isInAnyTree($rec["skill_id"])) {
-                $skill = new ilBasicSkill($rec["skill_id"]);
+            if ($this->tree_repo->isInAnyTree((int) $rec["skill_id"])) {
+                $skill = new ilBasicSkill((int) $rec["skill_id"]);
             }
         }
         return $skill;

--- a/Services/Skill/classes/class.ilBasicSkillTemplateGUI.php
+++ b/Services/Skill/classes/class.ilBasicSkillTemplateGUI.php
@@ -150,7 +150,7 @@ class ilBasicSkillTemplateGUI extends ilBasicSkillGUI
         );
     }
 
-    public function setTabs(string $a_tab = "") : void
+    public function setTabs(string $a_tab = "levels") : void
     {
         $ilTabs = $this->tabs;
         $ilCtrl = $this->ctrl;

--- a/Services/Skill/classes/class.ilBasicSkillTreeDBRepository.php
+++ b/Services/Skill/classes/class.ilBasicSkillTreeDBRepository.php
@@ -56,7 +56,7 @@ class ilBasicSkillTreeDBRepository implements ilBasicSkillTreeRepository
                 " ORDER BY n.creation_date DESC ");
             while ($rec = $ilDB->fetchAssoc($set)) {
                 if (($t = ilSkillTemplateReference::_lookupTemplateId($rec["obj_id"])) > 0) {
-                    $template_ids[$t] = $rec["obj_id"];
+                    $template_ids[$t] = (int) $rec["obj_id"];
                 }
             }
         } else {
@@ -86,7 +86,7 @@ class ilBasicSkillTreeDBRepository implements ilBasicSkillTreeRepository
             }
 
             foreach ($matching_trefs as $t) {
-                $results[] = array("skill_id" => $rec["obj_id"],
+                $results[] = array("skill_id" => (int) $rec["obj_id"],
                                    "tref_id" => $t,
                                    "creation_date" => $rec["creation_date"]
                 );
@@ -110,7 +110,7 @@ class ilBasicSkillTreeDBRepository implements ilBasicSkillTreeRepository
             " ORDER BY l.creation_date DESC ");
         $results = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
-            $results[] = array("level_id" => $rec["id"], "creation_date" => $rec["creation_date"]);
+            $results[] = array("level_id" => (int) $rec["id"], "creation_date" => $rec["creation_date"]);
         }
         return $results;
     }

--- a/Services/Skill/classes/class.ilBasicSkillUserLevelDBRepository.php
+++ b/Services/Skill/classes/class.ilBasicSkillUserLevelDBRepository.php
@@ -136,6 +136,9 @@ class ilBasicSkillUserLevelDBRepository implements ilBasicSkillUserLevelReposito
         return $recent;
     }
 
+    /**
+     * @return array<int, array[]>
+     */
     public function getNewAchievementsPerUser(
         string $a_timestamp,
         string $a_timestamp_to = null,
@@ -162,6 +165,16 @@ class ilBasicSkillUserLevelDBRepository implements ilBasicSkillUserLevelReposito
             " ORDER BY user_id, status_date ASC ");
         $achievements = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
+            $rec['user_id'] = (int) $rec['user_id'];
+            $rec['level_id'] = (int) $rec['level_id'];
+            $rec['skill_id'] = (int) $rec['skill_id'];
+            $rec['status'] = (int) $rec['status'];
+            $rec['valid'] = (int) $rec['valid'];
+            $rec['trigger_ref_id'] = (int) $rec['trigger_ref_id'];
+            $rec['trigger_obj_id'] = (int) $rec['trigger_obj_id'];
+            $rec['tref_id'] = (int) $rec['tref_id'];
+            $rec['self_eval'] = (int) $rec['self_eval'];
+            $rec['next_level_fullfilment'] = (float) $rec['next_level_fullfilment'];
             $achievements[$rec["user_id"]][] = $rec;
         }
 
@@ -408,6 +421,9 @@ class ilBasicSkillUserLevelDBRepository implements ilBasicSkillUserLevelReposito
         );
         $levels = [];
         while ($rec = $ilDB->fetchAssoc($set)) {
+            $rec['tref_id'] = (int) $rec['tref_id'];
+            $rec['skill_id'] = (int) $rec['skill_id'];
+            $rec['user_id'] = (int) $rec['user_id'];
             $levels[] = $rec;
         }
         return $levels;
@@ -487,10 +503,7 @@ class ilBasicSkillUserLevelDBRepository implements ilBasicSkillUserLevelReposito
             " AND self_eval = " . $ilDB->quote(1, "integer")
         );
 
-        if ($rec = $ilDB->fetchAssoc($set)) {
-            return true;
-        }
-        return false;
+        return !!$ilDB->fetchAssoc($set);
     }
 
     public function getLastLevelPerObject(
@@ -514,7 +527,7 @@ class ilBasicSkillUserLevelDBRepository implements ilBasicSkillUserLevelReposito
         );
 
         if ($rec = $ilDB->fetchAssoc($set)) {
-            return $rec["level_id"];
+            return (int) $rec["level_id"];
         }
 
         return 0;

--- a/Services/Skill/classes/class.ilObjSkillManagementGUI.php
+++ b/Services/Skill/classes/class.ilObjSkillManagementGUI.php
@@ -34,10 +34,7 @@ use ILIAS\Skill\Tree;
  */
 class ilObjSkillManagementGUI extends ilObjectGUI
 {
-    /**
-     * @var ilRbacSystem
-     */
-    protected $rbacsystem;
+    protected ilRbacSystem $rbacsystem;
     protected ilErrorHandling $error;
     protected ilTabsGUI $tabs;
     protected Factory $ui_fac;
@@ -54,7 +51,15 @@ class ilObjSkillManagementGUI extends ilObjectGUI
     protected int $requested_templates_tree = 0;
     protected string $requested_skexpand = "";
     protected int $requested_tmpmode = 0;
+
+    /**
+     * @var string[]
+     */
     protected array $requested_titles = [];
+
+    /**
+     * @var int[]
+     */
     protected array $requested_node_ids = [];
 
     /**
@@ -354,7 +359,7 @@ class ilObjSkillManagementGUI extends ilObjectGUI
         $this->ctrl->redirectByClass("skilltreeadmingui", "listTrees");
     }
 
-    public function saveAllTitles(bool $a_succ_mess = true)
+    public function saveAllTitles(bool $a_succ_mess = true) : void
     {
         $ilCtrl = $this->ctrl;
         $lng = $this->lng;
@@ -374,7 +379,7 @@ class ilObjSkillManagementGUI extends ilObjectGUI
         $ilCtrl->redirect($this, "editSkills");
     }
 
-    public function saveAllTemplateTitles(bool $a_succ_mess = true)
+    public function saveAllTemplateTitles(bool $a_succ_mess = true) : void
     {
         $ilCtrl = $this->ctrl;
         $lng = $this->lng;
@@ -394,7 +399,7 @@ class ilObjSkillManagementGUI extends ilObjectGUI
         $ilCtrl->redirect($this, "editSkillTemplates");
     }
 
-    public function expandAll(bool $a_redirect = true)
+    public function expandAll(bool $a_redirect = true) : void
     {
         $this->requested_skexpand = "";
         $n_id = ($this->requested_node_id > 0)
@@ -409,7 +414,7 @@ class ilObjSkillManagementGUI extends ilObjectGUI
         $this->saveAllTitles(false);
     }
 
-    public function collapseAll(bool $a_redirect = true)
+    public function collapseAll(bool $a_redirect = true) : void
     {
         $this->requested_skexpand = "";
         $n_id = ($this->requested_node_id > 0)
@@ -554,7 +559,7 @@ class ilObjSkillManagementGUI extends ilObjectGUI
     // Skill Templates
     //
 
-    public function editSkillTemplates()
+    public function editSkillTemplates() : void
     {
         $tpl = $this->tpl;
         $ilTabs = $this->tabs;
@@ -570,7 +575,7 @@ class ilObjSkillManagementGUI extends ilObjectGUI
     // Tree
     //
 
-    public function showTree(bool $a_templates, $a_gui = null, string $a_gui_cmd = "")
+    public function showTree(bool $a_templates, $a_gui = null, string $a_gui_cmd = "") : void
     {
         $ilUser = $this->user;
         $tpl = $this->tpl;

--- a/Services/Skill/classes/class.ilPersonalSkillExplorerGUI.php
+++ b/Services/Skill/classes/class.ilPersonalSkillExplorerGUI.php
@@ -27,19 +27,38 @@ use ILIAS\Skill\Tree\SkillTreeManager;
  */
 class ilPersonalSkillExplorerGUI extends ilTreeExplorerGUI
 {
-
-    /**
-     * @var object|string
-     */
-    protected $select_gui = "";
+    protected string $select_gui = "";
     protected string $select_cmd = "";
     protected string $select_par = "";
+
+    /**
+     * @var array{child: int, parent: int}[]
+     */
     protected array $all_nodes = [];
+
+    /**
+     * @var array<int, array{child: int, parent: int}>
+     */
     protected array $node = [];
+
+    /**
+     * @var array<int, array{child: int, parent: int}[]>
+     */
     protected array $child_nodes = [];
+
+    /**
+     * @var array<int, int>
+     */
     protected array $parent = [];
 
+    /**
+     * @var array<int, bool>
+     */
     protected array $selectable = [];
+
+    /**
+     * @var array<int, array{child: int, parent: int}[]>
+     */
     protected array $selectable_child_nodes = [];
     protected bool $has_selectable_nodes = false;
 

--- a/Services/Skill/classes/class.ilPersonalSkillsGUI.php
+++ b/Services/Skill/classes/class.ilPersonalSkillsGUI.php
@@ -36,11 +36,27 @@ class ilPersonalSkillsGUI
     public const LIST_PROFILES = "";
 
     protected string $offline_mode = "";
+
+    /**
+     * @var array<int, array<int, int>>
+     */
     protected array $actual_levels = [];
+
+    /**
+     * @var array<int, array<int, int>>
+     */
     protected array $gap_self_eval_levels = [];
     protected bool $history_view = false;
+
+    /**
+     * @var int[]
+     */
     protected array $trigger_objects_filter = [];
     protected string $intro_text = "";
+
+    /**
+     * @var string[]
+     */
     protected array $hidden_skills = [];
     protected string $mode = "";
     protected string $gap_mode = "";
@@ -63,10 +79,26 @@ class ilPersonalSkillsGUI
     protected ResourceStorage $storage;
 
     protected int $obj_id = 0;
+
+    /**
+     * @var array<string, array{base_skill_id: int, tref_id: int, title: int}>
+     */
     protected array $obj_skills = [];
     protected int $profile_id = 0;
+
+    /**
+     * @var array{base_skill_id: int, tref_id: int, level_id: int, order_nr: int}[]
+     */
     protected array $profile_levels = [];
+
+    /**
+     * @var array{id: int, title: string, description: string, image_id: string}[]
+     */
     protected array $user_profiles = [];
+
+    /**
+     * @var array<int, array{profile_id: int, role_id: int, title: string}|{profile_id: int}>
+     */
     protected array $cont_profiles = [];
     protected bool $use_materials = false;
     protected ilSkillManagementSettings $skmg_settings;
@@ -78,13 +110,25 @@ class ilPersonalSkillsGUI
     protected int $requested_node_id = 0;
     protected int $requested_profile_id = 0;
     protected int $requested_skill_id = 0;
+
+    /**
+     * @var int[]
+     */
     protected array $requested_skill_ids = [];
     protected int $requested_basic_skill_id = 0;
     protected int $requested_tref_id = 0;
     protected int $requested_level_id = 0;
     protected int $requested_self_eval_level_id = 0;
     protected int $requested_wsp_id = 0;
+
+    /**
+     * @var int[]
+     */
     protected array $requested_wsp_ids = [];
+
+    /**
+     * @var string[]
+     */
     protected array $trigger_user_filter = [];
 
     public function __construct()
@@ -161,7 +205,7 @@ class ilPersonalSkillsGUI
     }
     
     /**
-     * @param array $a_val self evaluation values key1: base_skill_id, key2: tref_id: value: level id
+     * @param array<int, array<int, int>> $a_val self evaluation values key1: base_skill_id, key2: tref_id: value: level id
      */
     public function setGapAnalysisSelfEvalLevels(array $a_val) : void
     {
@@ -207,17 +251,17 @@ class ilPersonalSkillsGUI
     }
 
     /**
-     * @return array
+     * @return string[]
      */
-    public function getTriggerUserFilter()
+    public function getTriggerUserFilter() : array
     {
         return $this->trigger_user_filter;
     }
 
     /**
-     * @param array $trigger_user_filter
+     * @param string[] $trigger_user_filter
      */
-    public function setTriggerUserFilter($trigger_user_filter)
+    public function setTriggerUserFilter(array $trigger_user_filter) : void
     {
         $this->trigger_user_filter = $trigger_user_filter;
     }
@@ -263,12 +307,18 @@ class ilPersonalSkillsGUI
         return $this->obj_id;
     }
 
+    /**
+     * @return array<string, array{base_skill_id: int, tref_id: int, title: int}>
+     */
     public function getObjectSkills() : array
     {
         return $this->obj_skills;
     }
 
-    public function setObjectSkills(int $a_obj_id, ?array $a_skills = null) : void
+    /**
+     * @param array<string, array{base_skill_id: int, tref_id: int, title: int}> $a_skills
+     */
+    public function setObjectSkills(int $a_obj_id, array $a_skills) : void
     {
         $this->obj_id = $a_obj_id;
         $this->obj_skills = $a_skills;
@@ -902,7 +952,7 @@ class ilPersonalSkillsGUI
                     $this->requested_tref_id,
                     $this->requested_basic_skill_id,
                     $this->requested_level_id,
-                    (int) $w
+                    $w
                 );
             }
             $this->tpl->setOnScreenMessage('success', $lng->txt("msg_obj_modified"), true);
@@ -1124,7 +1174,7 @@ class ilPersonalSkillsGUI
         $this->mode = "gap";
     }
 
-    public function getGapAnalysisHTML($a_user_id = 0, array $a_skills = null) : string
+    public function getGapAnalysisHTML(int $a_user_id = 0, array $a_skills = null) : string
     {
         $ilUser = $this->user;
         $lng = $this->lng;

--- a/Services/Skill/classes/class.ilSkillDataSet.php
+++ b/Services/Skill/classes/class.ilSkillDataSet.php
@@ -44,7 +44,14 @@ class ilSkillDataSet extends ilDataSet
     protected int $init_top_order_nr = 0;
     protected int $init_templ_top_order_nr = 0;
 
+    /**
+     * @var int[]
+     */
     protected array $selected_nodes = [];
+
+    /**
+     * @var int[]
+     */
     protected array $selected_profiles = [];
     protected string $mode = "";
 
@@ -494,6 +501,11 @@ class ilSkillDataSet extends ilDataSet
         }
     }
 
+    /**
+     * @param array{Id: int, Child: int Type: string} $a_rec
+     *
+     * @return array<string, array{ids: int[]}>
+     */
     protected function getDependencies(
         string $a_entity,
         string $a_version,
@@ -551,7 +563,7 @@ class ilSkillDataSet extends ilDataSet
                     $set = $ilDB->query("SELECT DISTINCT(templ_id) FROM skl_templ_ref " .
                             " WHERE " . $ilDB->in("skl_node_id", $ref_nodes, false, "integer"));
                     while ($rec = $ilDB->fetchAssoc($set)) {
-                        $deps["skl_templ_subtree"]["ids"][] = $rec["templ_id"];
+                        $deps["skl_templ_subtree"]["ids"][] = (int) $rec["templ_id"];
                     }
 
                     // export subtree after templates

--- a/Services/Skill/classes/class.ilSkillExportConfig.php
+++ b/Services/Skill/classes/class.ilSkillExportConfig.php
@@ -27,7 +27,15 @@ class ilSkillExportConfig extends ilExportConfig
 {
     public const MODE_SKILLS = "";
     public const MODE_PROFILES = "prof";
+
+    /**
+     * @var int[]
+     */
     protected array $selected_nodes = [];
+
+    /**
+     * @var int[]
+     */
     protected array $selected_profiles = [];
     protected string $mode = "";
     protected int $skill_tree_id = 0;

--- a/Services/Skill/classes/class.ilSkillSelectorGUI.php
+++ b/Services/Skill/classes/class.ilSkillSelectorGUI.php
@@ -26,13 +26,14 @@ use ILIAS\Skill\Service\SkillAdminGUIRequest;
  */
 class ilSkillSelectorGUI extends ilVirtualSkillTreeExplorerGUI
 {
-    /**
-     * @var object|string
-     */
-    protected $select_gui = "";
+    protected string $select_gui = "";
     protected string $select_cmd = "";
     protected string $select_par = "";
     protected SkillAdminGUIRequest $admin_gui_request;
+
+    /**
+     * @var string[]
+     */
     protected array $requested_selected_ids = [];
 
     public function __construct(

--- a/Services/Skill/classes/class.ilSkillTemplateReferenceGUI.php
+++ b/Services/Skill/classes/class.ilSkillTemplateReferenceGUI.php
@@ -73,7 +73,7 @@ class ilSkillTemplateReferenceGUI extends ilBasicSkillTemplateGUI
         }
     }
 
-    public function setTabs($a_tab = "") : void
+    public function setTabs($a_tab = "levels") : void
     {
         $ilTabs = $this->tabs;
         $ilCtrl = $this->ctrl;

--- a/Services/Skill/classes/class.ilSkillUsage.php
+++ b/Services/Skill/classes/class.ilSkillUsage.php
@@ -49,7 +49,7 @@ class ilSkillUsage implements ilSkillUsageInfo
     /**
      * @var ilSkillUsageInfo[]
      */
-    protected $classes = [ilBasicSkill::class, ilPersonalSkill::class, ilSkillProfile::class,
+    protected array $classes = [ilBasicSkill::class, ilPersonalSkill::class, ilSkillProfile::class,
                           ilSkillResources::class, ilSkillUsage::class];
 
     protected ilBasicSkillTreeRepository $tree_repo;
@@ -90,7 +90,7 @@ class ilSkillUsage implements ilSkillUsageInfo
     }
     
     /**
-     * @return array|int[]
+     * @return int[]
      */
     public static function getUsages(int $a_skill_id, int $a_tref_id) : array
     {
@@ -111,11 +111,15 @@ class ilSkillUsage implements ilSkillUsageInfo
         return $obj_ids;
     }
 
-    public static function getUsageInfo(array $a_cskill_ids, array &$a_usages) : void
+    /**
+     * @param array{skill_id: int tref_id: int}[] $a_cskill_ids
+     *
+     * @return array<string, array<string, array{key: string}[]>>
+     */
+    public static function getUsageInfo(array $a_cskill_ids) : array
     {
-        self::getUsageInfoGeneric(
+        return self::getUsageInfoGeneric(
             $a_cskill_ids,
-            $a_usages,
             ilSkillUsage::TYPE_GENERAL,
             "skl_usage",
             "obj_id"
@@ -124,22 +128,26 @@ class ilSkillUsage implements ilSkillUsageInfo
     
     /**
      * Get standard usage query
+     * @param array{skill_id: int tref_id: int}[] $a_cskill_ids
+     *
+     * @return array<string, array<string, array{key: string}[]>>
      */
     public static function getUsageInfoGeneric(
         array $a_cskill_ids,
-        array &$a_usages,
         string $a_usage_type,
         string $a_table,
         string $a_key_field,
         string $a_skill_field = "skill_id",
         string $a_tref_field = "tref_id"
-    ) : void {
+    ) : array {
         global $DIC;
+
+        $a_usages = [];
 
         $ilDB = $DIC->database();
 
         if (count($a_cskill_ids) == 0) {
-            return;
+            return [];
         }
 
         $w = "WHERE";
@@ -156,11 +164,13 @@ class ilSkillUsage implements ilSkillUsageInfo
             $a_usages[$rec[$a_skill_field] . ":" . $rec[$a_tref_field]][$a_usage_type][] =
                     array("key" => $rec[$a_key_field]);
         }
+
+        return $a_usages;
     }
 
     /**
-     * @param array $a_cskill_ids array of common skill ids ("skill_id" => skill_id, "tref_id" => tref_id)
-     * @return array
+     * @param array{skill_id: int, tref_id: int}[] $a_cskill_ids array of common skill ids ("skill_id" => skill_id, "tref_id" => tref_id)
+     * @return array<string, array<string, array{key: string}[]>>
      */
     public function getAllUsagesInfo(array $a_cskill_ids) : array
     {
@@ -168,14 +178,14 @@ class ilSkillUsage implements ilSkillUsageInfo
         
         $usages = [];
         foreach ($classes as $class) {
-            $class::getUsageInfo($a_cskill_ids, $usages);
+            $usages = array_merge_recursive($usages, $class::getUsageInfo($a_cskill_ids));
         }
         return $usages;
     }
 
     /**
      * @param array $a_tree_ids array of common skill ids ("skill_id" => skill_id, "tref_id" => tref_id)
-     * @return array
+     * @return array<string, array<string, array{key: string}[]>>
      */
     public function getAllUsagesInfoOfTrees(array $a_tree_ids) : array
     {
@@ -193,6 +203,9 @@ class ilSkillUsage implements ilSkillUsageInfo
         return $this->getAllUsagesInfo($allnodes);
     }
 
+    /**
+     * @return array<string, array<string, array{key: string}[]>>
+     */
     public function getAllUsagesInfoOfSubtree(int $a_skill_id, int $a_tref_id = 0) : array
     {
         // get nodes
@@ -204,7 +217,7 @@ class ilSkillUsage implements ilSkillUsageInfo
 
     /**
      * @param array $a_cskill_ids array of common skill ids ("skill_id" => skill_id, "tref_id" => tref_id)
-     * @return array
+     * @return array<string, array<string, array{key: string}[]>>
      */
     public function getAllUsagesInfoOfSubtrees(array $a_cskill_ids) : array
     {
@@ -221,6 +234,9 @@ class ilSkillUsage implements ilSkillUsageInfo
         return $this->getAllUsagesInfo($allnodes);
     }
 
+    /**
+     * @return array<string, array<string, array{key: string}[]>>
+     */
     public function getAllUsagesOfTemplate(int $a_template_id) : array
     {
         $skill_logger = ilLoggerFactory::getLogger('skll');
@@ -275,6 +291,9 @@ class ilSkillUsage implements ilSkillUsageInfo
         }
     }
 
+    /**
+     * @return int[]
+     */
     public function getAssignedObjectsForSkill(int $a_skill_id, int $a_tref_id) : array
     {
         //$objects = $this->getAllUsagesInfoOfSubtree($a_skill_id, $a_tref_id);
@@ -283,19 +302,20 @@ class ilSkillUsage implements ilSkillUsageInfo
         return $objects;
     }
 
+    /**
+     * @return string[]
+     */
     public function getAssignedObjectsForSkillTemplate(int $a_template_id) : array
     {
         $usages = $this->getAllUsagesOfTemplate($a_template_id);
         $obj_usages = array_column($usages, "gen");
-        $objects = [];
-        $objects["objects"] = [];
-        foreach ($obj_usages as $obj) {
-            $objects["objects"] = array_column($obj, "key");
-        }
 
-        return $objects["objects"];
+        return array_column(current(array_reverse($obj_usages)) ?: [], 'key');
     }
 
+    /**
+     * @return int[]
+     */
     public function getAssignedObjectsForSkillProfile(int $a_profile_id) : array
     {
         $profile = new ilSkillProfile($a_profile_id);

--- a/Services/Skill/interfaces/interface.ilBasicSkillUserLevelRepository.php
+++ b/Services/Skill/interfaces/interface.ilBasicSkillUserLevelRepository.php
@@ -102,7 +102,8 @@ interface ilBasicSkillUserLevelRepository
         int $a_tref_id = 0,
         bool $a_self_eval = false,
         string $a_unique_identifier = "",
-        float $a_next_level_fulfilment = 0.0
+        float $a_next_level_fulfilment = 0.0,
+        string $trigger_user_id = ""
     ) : void;
 
     /**

--- a/Services/Skill/interfaces/interface.ilSkillUsageInfo.php
+++ b/Services/Skill/interfaces/interface.ilSkillUsageInfo.php
@@ -28,8 +28,9 @@ interface ilSkillUsageInfo
     /**
      * Get title of an assigned item
      *
-     * @param array $a_cskill_ids array of common skill ids ("skill_id" => skill_id, "tref_id" => tref_id)
-     * @param array $a_usages
+     * @param array{skill_id: int, tref_id: int}[] $a_cskill_ids array of common skill ids
+     *
+     * @return array<string, array<string, array{key: string}[]>>
      */
-    public static function getUsageInfo(array $a_cskill_ids, array &$a_usages);
+    public static function getUsageInfo(array $a_cskill_ids) : array;
 }


### PR DESCRIPTION
Kannst du folgendes nochmal absegnen / double checken?

### getUsageInfo* Referenz zu return Wert

`getUsageInfo*` wurden von references auf arrays umgebaut. Meinen "Berechnungen" nach passt das daher mit `array_merge_recursively`:

`Services/Skill/classes/class.ilSkillUsage.php:181:` hier wird es verwendet

Alle anderen Stellen dazu:

`Services/Skill/interfaces/interface.ilSkillUsageInfo.php:35:`

`Services/Skill/Resources/class.ilSkillResources.php:184:`

`Services/Skill/Profile/class.ilSkillProfile.php:765:`

`Services/Skill/classes/class.ilSkillUsage.php:119:`

`Services/Skill/classes/class.ilSkillUsage.php:135:`

`Services/Skill/classes/class.ilPersonalSkill.php:294:`

`Services/Skill/classes/class.ilBasicSkill.php:546:`

### Unnötiges array_column

`array_map` behält die keys bereits bei, daher ist das `array_column` unnötig und `(int)` cast und `(bool)` cast wurden durch `intval` und `boolval` ersetzt:

`Services/Skill/Service/classes/class.SkillGUIRequest.php:75:`

`Services/Skill/Service/classes/class.SkillGUIRequest.php:102:`

`Services/Skill/Service/classes/class.SkillGUIRequest.php:134:`

### Umbau von `max(...)`
Die keys von `$childs` sind numerisch, sollte daher kein Problem sein:

`Services/Skill/Tree/class.ilSkillTree.php:118:`